### PR TITLE
create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Expo Examples
+
+This repo contains a whole bunch of examples to be able to see Expo in action! There are folders of complete projects
+for you to take a look at, as well as a couple of [Snacks](https://expo.io/tools#snack) that make it quick and easy to see our
+[APIs](https://docs.expo.io/versions/v32.0.0/sdk/overview/) at work.
+
+## Full Projects
+- [Detox Testing](https://github.com/expo/examples/tree/master/with-detox-tests)
+- [Facebook Authentication](https://github.com/expo/examples/tree/master/with-facebook-auth)
+- [Uploading an Image to Server (using FormData)](https://github.com/expo/examples/tree/master/with-formdata-image-upload)
+- [Hooks](https://github.com/expo/examples/tree/master/with-postpublish-hooks)
+- [React Native Calendars](https://github.com/expo/examples/tree/master/with-react-native-calendars)
+- [Redux](https://github.com/expo/examples/tree/master/with-redux) (along with React Animated, all in one file)
+- [Socket-io: Websocket](https://github.com/expo/examples/tree/master/with-socket-io)
+- [Three.js](https://github.com/expo/examples/tree/master/with-three-js)
+- [Victory Native](https://github.com/expo/examples/tree/master/with-victory-native)
+- [WebBrowser Redirect](https://github.com/expo/examples/tree/master/with-webbrowser-redirect)
+
+## Snack Links (in progress of adding more)
+- [Example Snack](https://snack.expo.io/@documentation/pushnotifications) for the [Notifications](https://docs.expo.io/versions/v32.0.0/sdk/notifications/) API.
+ Expo's guide for Push Notifications can be found [here](https://docs.expo.io/versions/v32.0.0/guides/push-notifications/).
+ 


### PR DESCRIPTION
Just makes it a little more welcoming/easier to navigate. May be a little too filled with links, but assumed most visitors to the examples repo will be new to Expo/React Native