### PR TITLE
Replace exp and xde references with expo cli

### DIFF
--- a/with-detox-tests/README.md
+++ b/with-detox-tests/README.md
@@ -7,7 +7,7 @@
 ### Run the tests
 
 1. [Install dependencies](https://github.com/wix/detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies) (only follow Step 1 from this guide for now, the rest is already done in this project)
-2. Start the packager: `exp start` (if you don't have `exp` installed, `yarn global add exp`).
+2. Start the packager: [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/) (if you don't have `expo` installed, `yarn global add expo-cli`).
 3. `npm run e2e`
 
 ## The idea behind this example

--- a/with-facebook-auth/README.md
+++ b/with-facebook-auth/README.md
@@ -6,8 +6,8 @@ Try it at https://expo.io/@community/with-facebook-auth
 
 ### Running the app
 
-- `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 - Press "Open FB Auth" in the app and then check your logs. Take the `redirectUrl` that was logged and enter it into the "Valid OAuth redirect URIs" in your Facebook app configuration step below.
 
 ### Setting up the Facebook app

--- a/with-formdata-image-upload/README.md
+++ b/with-formdata-image-upload/README.md
@@ -7,11 +7,11 @@ Try it at https://expo.io/@community/image-upload-example
 ### Running the app
 
 - `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Open `app` with [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ### Running the server
 
-- By default, the app will use a server that is already deployed in order to upload the image to S3. If you want to deploy your own, follow the steps in the [backend directory](https://github.com/expo/examples/tree/master/with-formdata-image-upload/backend). 
+- By default, the app will use a server that is already deployed in order to upload the image to S3. If you want to deploy your own, follow the steps in the [backend directory](https://github.com/expo/examples/tree/master/with-formdata-image-upload/backend).
 
 ## The idea behind the example
 

--- a/with-postpublish-hooks/README.md
+++ b/with-postpublish-hooks/README.md
@@ -11,8 +11,8 @@ entirely from `app.json`.
 
 ## Running the app
 
-- `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 

--- a/with-react-native-calendars/README.md
+++ b/with-react-native-calendars/README.md
@@ -6,8 +6,8 @@ Try it at https://expo.io/@community/react-native-calendars-example
 
 ### Running the app
 
-- `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 

--- a/with-redux/README.md
+++ b/with-redux/README.md
@@ -4,8 +4,8 @@
 
 ### Running the app
 
-- `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 

--- a/with-socket-io/README.md
+++ b/with-socket-io/README.md
@@ -7,7 +7,7 @@ Try it at https://expo.io/@community/socket-io-example
 ## Running the app
 
 - `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Open `app` with [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ### Running the server (optional)
 

--- a/with-victory-native/README.md
+++ b/with-victory-native/README.md
@@ -7,7 +7,7 @@ Try it at https://expo.io/@community/victory-native-example
 ## Running the app
 
 - Run `yarn` or `npm install`
-- Open this directory with `exp` or XDE, try it out.
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 

--- a/with-webbrowser-redirect/README.md
+++ b/with-webbrowser-redirect/README.md
@@ -7,7 +7,7 @@ Try it at https://expo.io/@community/with-webbrowser-redirect
 ### Running the app
 
 - `cd` into the `app` directory and run `yarn` or `npm install`
-- Open `app` with `exp` or XDE, try it out.
+- Open `app` with [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 


### PR DESCRIPTION
This "purges" the old references to Exp and XDE, replacing them with the latest Expo CLI. I also added a link to the docs, mostly for new developers not knowing about this tool yet.

Also, I fixed some references in readme's about a sub-`app`-folder. Those folders aren't using the app folders and might confuse some people, although it should be quite obvious 😄

These aren't using `app` folders: 
- with-facebook-auth
- with-postpublish-hooks
- with-react-native-calendars
- with-redux