### PR TITLE
[storybook][native] update storybook example to run on native device

### DIFF
--- a/with-storybook/.storybook/config.native.js
+++ b/with-storybook/.storybook/config.native.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {
+  addDecorator,
+  configure,
+  getStorybookUI
+} from '@storybook/react-native';
+import { View } from 'react-native';
+
+// Since require.context doesn't exist in metro bundler world, we have to
+// manually import files ending in *.stories.js
+const getStories = () => require('../stories');
+
+// Lazy margin at top for notches etc
+addDecorator(StoryFn => (
+  <View style={{ marginTop: 40, marginHorizontal: 10 }}>
+    <StoryFn />
+  </View>
+));
+
+configure(() => {
+  getStories();
+}, module);
+
+export const OnDeviceStorybookUI = getStorybookUI();

--- a/with-storybook/App.tsx
+++ b/with-storybook/App.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { OnDeviceStorybookUI } from './.storybook/config';
 
-export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-    </View>
-  );
-}
+export default OnDeviceStorybookUI;
 
 const styles = StyleSheet.create({
   container: {

--- a/with-storybook/package.json
+++ b/with-storybook/package.json
@@ -23,6 +23,7 @@
     "@storybook/addon-links": "^5.2.1",
     "@storybook/addons": "^5.2.1",
     "@storybook/react": "^5.2.1",
+    "@storybook/react-native": "^5.2.3",
     "@types/react": "^16.8.23",
     "@types/react-native": "^0.57.65",
     "babel-loader": "^8.0.6",

--- a/with-storybook/stories/0-Welcome.stories.js
+++ b/with-storybook/stories/0-Welcome.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { linkTo } from '@storybook/addon-links';
+import { storiesOf } from '@storybook/react-native';
 import { Welcome } from '@storybook/react/demo';
 
 export default {
@@ -11,3 +12,6 @@ export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;
 toStorybook.story = {
   name: 'to Storybook',
 };
+
+// On-Device Register
+storiesOf('Welcome', module).add(toStorybook.story.name, toStorybook);

--- a/with-storybook/stories/1-Button.stories.js
+++ b/with-storybook/stories/1-Button.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react-native';
 import { Button } from 'react-native';
 
 export default {
@@ -9,3 +10,6 @@ export default {
 export const text = () => (
   <Button title="Hello Button" onPress={action('clicked')} />
 );
+
+// On-Device Register
+storiesOf('Button', module).add('Text', text);

--- a/with-storybook/stories/2-Constants.stories.js
+++ b/with-storybook/stories/2-Constants.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react-native';
 import Constants from 'expo-constants';
 import { Text } from 'react-native';
 
@@ -10,3 +10,6 @@ export default {
 export const constants = () => (
   <Text>{JSON.stringify(Constants, null, 2)}</Text>
 );
+
+// On-Device Register
+storiesOf('Constants', module).add('Constants', constants);

--- a/with-storybook/stories/3-LinearGradient.stories.js
+++ b/with-storybook/stories/3-LinearGradient.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 
 export default {
@@ -12,3 +12,6 @@ export const linearGradient = () => (
     colors={['red', 'blue', 'yellow']}
   />
 );
+
+// On-Device Register
+storiesOf('LinearGradient', module).add('Linear Gradient', linearGradient);

--- a/with-storybook/stories/4-Font.stories.js
+++ b/with-storybook/stories/4-Font.stories.js
@@ -13,23 +13,25 @@ export function font() {
   useEffect(() => {
     (async () => {
       await Font.loadAsync({
-        'retro-regular': require('../assets/retro-regular.ttf'),
+        'retro-regular': require('../assets/retro-regular.ttf')
       });
       setLoaded(true);
     })();
   }, []);
 
   return (
-    <Text
-      style={{
-        fontFamily: 'retro-regular',
-        backgroundColor: 'transparent',
-        fontSize: 56,
-        color: '#000',
-      }}
-    >
-      Cool new font
-    </Text>
+    loaded && (
+      <Text
+        style={{
+          fontFamily: 'retro-regular',
+          backgroundColor: 'transparent',
+          fontSize: 56,
+          color: '#000'
+        }}
+      >
+        Cool new font
+      </Text>
+    )
   );
 }
 

--- a/with-storybook/stories/4-Font.stories.js
+++ b/with-storybook/stories/4-Font.stories.js
@@ -1,5 +1,6 @@
-import * as Font from 'expo-font';
 import React, { useEffect, useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import * as Font from 'expo-font';
 import { Text } from 'react-native';
 
 export default {
@@ -31,3 +32,6 @@ export function font() {
     </Text>
   );
 }
+
+// On-Device Register
+storiesOf('Font', module).add('Font', font);

--- a/with-storybook/stories/index.native.js
+++ b/with-storybook/stories/index.native.js
@@ -1,0 +1,4 @@
+import './1-Button.stories';
+import './2-Constants.stories';
+import './3-LinearGradient.stories';
+import './4-Font.stories';


### PR DESCRIPTION
Updated the with-storybook example to show how you run @storybook/react-native on device.

It will just show when you kick off expo in a native simulator. 

Having a seperate `.native.js` config is pretty annoying but you can see there are lots of differences in how you get onDevice storybook running. Also no `require.context` on metro is less than great. I've tried [storybook-loader](https://github.com/elderfo/react-native-storybook-loader) before but it always flakes out on me.

Hope this helps

<img width="457" alt="Screen Shot 2019-10-10 at 13 09 13" src="https://user-images.githubusercontent.com/927600/66529535-519ad480-eb60-11e9-8e8f-b67886e9afae.png">
