### PR TITLE
feat: add firebase database example

### DIFF
--- a/with-firebase/App.js
+++ b/with-firebase/App.js
@@ -1,0 +1,121 @@
+import * as firebase from 'firebase';
+import React from 'react';
+import {
+  ActivityIndicator,
+  Button,
+  Dimensions,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyAmG9vvm5PUzVYxV_QR0KFOGyZ9sE8kKBo",
+  authDomain: "fir-test-c3482.firebaseapp.com",
+  databaseURL: "https://fir-test-c3482.firebaseio.com",
+  storageBucket: "",
+  messagingSenderId: "817842099542"
+};
+
+firebase.initializeApp(firebaseConfig);
+
+export default class App extends React.Component {
+  state = {
+    text: '',
+    loading: false,
+  }
+
+  componentWillMount() {
+    let initialLoad = true;
+    this.setState({loading: true});
+
+    firebase.database().ref('example').on('value', (snapshot) => {
+      this.setState({text: snapshot.val() && snapshot.val().text});
+
+      if (initialLoad) {
+        this.setState({loading: false});
+        initialLoad = false;
+      }
+    });
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>
+          Store some value in Firebase!
+        </Text>
+
+        <TextInput
+          onChangeText={text => { this.setState({text}) }}
+          onSubmitEditing={this._saveValue}
+          value={this.state.text}
+          style={styles.textInput}
+        />
+
+        <Button
+          onPress={this._saveValue}
+          title="Save"
+        />
+
+        {this._maybeRenderLoadingOverlay()}
+      </View>
+    );
+  }
+
+  _saveValue = async () => {
+    try {
+      this.setState({loading: true});
+      await firebase.database().ref('example').set({ text: this.state.text });
+    } catch(e) {
+      // Error! oh no
+      console.log(e);
+      alert('Oh no, couldn\'t store your input');
+    } finally {
+      this.setState({loading: false});
+    }
+  }
+
+  _maybeRenderLoadingOverlay = () => {
+    if (this.state.loading) {
+      return (
+        <View style={[StyleSheet.absoluteFill, styles.loadingOverlay]}>
+          <ActivityIndicator
+            color="#fff"
+            animating
+            size="large"
+          />
+        </View>
+      );
+    }
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+  },
+  textInput: {
+    width: Dimensions.get('window').width - 30,
+    marginHorizontal: 15,
+    padding: 5,
+    borderRadius: 2,
+    borderWidth: 1,
+    borderColor: '#eee',
+    marginVertical: 15,
+    height: 50,
+    fontSize: 16,
+  },
+  loadingOverlay: {
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/with-firebase/App.js
+++ b/with-firebase/App.js
@@ -23,12 +23,11 @@ firebase.initializeApp(firebaseConfig);
 export default class App extends React.Component {
   state = {
     text: '',
-    loading: false,
+    loading: true,
   }
 
-  componentWillMount() {
+  componentDidMount() {
     let initialLoad = true;
-    this.setState({loading: true});
 
     firebase.database().ref('example').on('value', (snapshot) => {
       this.setState({text: snapshot.val() && snapshot.val().text});

--- a/with-firebase/README.md
+++ b/with-firebase/README.md
@@ -1,0 +1,24 @@
+# Firebase Example
+
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+  <!-- Web -->
+  <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
+</p>
+
+This example demonstrates how you can save some text to Firebase Database. When you save the input value it becomes visible in Firebase.
+
+## 🚀 How to use
+
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Type something you want to save
+- Press save and see your input in Firebase!
+
+## 📝 Notes
+
+- [Firebase JS docs](https://firebase.google.com/docs/web/setup)
+- [Expo Firebase guide](https://docs.expo.io/versions/latest/guides/using-firebase/)

--- a/with-firebase/app.json
+++ b/with-firebase/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "with-firebase",
+    "version": "1.0.0",
+    "icon": "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/icon.png?raw=true",
+    "splash": {
+      "image": "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/splash.png?raw=true",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    }
+  }
+}

--- a/with-firebase/babel.config.js
+++ b/with-firebase/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+    api.cache(true);
+    return {
+      presets: ['babel-preset-expo'],
+    };
+  };

--- a/with-firebase/package.json
+++ b/with-firebase/package.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "expo": "36.0.0",
+    "firebase": "7.8.1",
+    "react": "16.9.0",
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native-web": "0.11.7"
+  },
+  "devDependencies": {
+    "@babel/core": "7.0.0",
+    "babel-preset-expo": "8.0.0"
+  }
+}


### PR DESCRIPTION
Fixes #52 

I think it needs just a tiny bit of love before merging:

1. The current credentials aren't working, at least on my end. Should we create new ones, or just instruct people to use their own?
2. The example itself is just half of the whole firebase set/get cycle. Maybe it's also nice to listen to these values and render them below the save button? 

If we do 2, we might want to create UUIDs or let users create their own credentials to avoid people seeing input from other people. I'm not sure if that's a good idea 😅

> Ps, I snatched the `expo-examples` project name on Firebase. If you want it, ping me on Slack 😬