### PR TITLE
feat: add login with twitter example

### DIFF
--- a/with-twitter-auth/README.md
+++ b/with-twitter-auth/README.md
@@ -15,7 +15,7 @@ The purpose of the backend is to store the Twitter API keys without leaking this
 
 - Create your own [Twitter app](https://developer.twitter.com/en/apps/create)
 - Mark the checkbox `Enable Sign in with Twitter`
-- Add the AuthSession's Callback URL (read more about this below)
+- Add the AuthSession's Callback URL ([read more here](#authsession-callback-url))
 
 #### Prepare the backend
 

--- a/with-twitter-auth/README.md
+++ b/with-twitter-auth/README.md
@@ -36,7 +36,7 @@ The purpose of the backend is to store the Twitter API keys without leaking this
 ```
 Expo Twitter Auth
 ├── app ➡️ Expo application with Twitter auth
-└── backend - Simple API to fetch request and access tokens
+└── backend ➡️ Simple API to fetch request and access tokens
 ```
 
 ## 📝 Notes

--- a/with-twitter-auth/README.md
+++ b/with-twitter-auth/README.md
@@ -1,0 +1,55 @@
+# Twitter Auth Example
+
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+</p>
+
+This example demonstrates how to implement a "login with Twitter" button, using a simple backend and the AuthSession module.
+
+The purpose of the backend is to store the Twitter API keys without leaking this in your app. It also uses a node Twitter library called "[Twitter Lite](https://github.com/draftbit/twitter-lite)" to simplify the API calls.
+
+## 🚀 How to use
+
+- Create your own [Twitter app](https://developer.twitter.com/en/apps/create)
+- Mark the checkbox `Enable Sign in with Twitter`
+- Add the AuthSession's Callback URL (read more about this below)
+
+#### Prepare the backend
+
+- Go to directory `backend`
+- Install with `yarn` or `npm install`
+- Open `index.js` and replace `consumer_key` and `consumer_secret` with your Twitter app keys
+- Run `node index.js` to start the backend
+
+#### Set up the app
+
+- Go to directory `app`
+- Install with `yarn` or `npm install`
+- Open `App.js` and replace `requestTokenURL` and `accessTokenURL` with your backend URLs
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out
+
+### 📁 File Structure
+
+```
+Expo Twitter Auth
+├── app ➡️ Expo application with Twitter auth
+└── backend - Simple API to fetch request and access tokens
+```
+
+## 📝 Notes
+
+- [Expo AuthSession docs](https://docs.expo.io/versions/latest/sdk/auth-session/)
+- [Twitter Lite docs](https://github.com/draftbit/twitter-lite)
+- [Login with Twitter guide](https://developer.twitter.com/en/docs/basics/authentication/guides/log-in-with-twitter)
+- [Twitter authentication best practices](https://developer.twitter.com/en/docs/basics/authentication/guides/authentication-best-practices)
+
+#### AuthSession callback URL
+
+The AuthSession helps you with browser authentication, without the need of an additional server or website. To use this with Twitter authentication flows, we need to tell Twitter that the callback URLs are allowed.
+
+Each Expo user has it's own URL for different projects, the basic structure of this URL is `https://auth.expo.io/@your-username/your-expo-app-slug`. If you are signed in as `awesome-ppl`, and your app is called `meme-explorer`, your URL looks like `https://auth.expo.io/@awesome-ppl/meme-explorer`.
+
+> [Read more about AuthSession here](https://docs.expo.io/versions/latest/sdk/auth-session/)

--- a/with-twitter-auth/app/App.js
+++ b/with-twitter-auth/app/App.js
@@ -45,7 +45,7 @@ export default function App() {
       // Validate if the auth session response is successful
       // Note, we still receive a `authResponse.type = 'success'`, thats why we need to check on the params itself
       if (authResponse.params && authResponse.params.denied) {
-        return setError('AuthSession was not successful, user did not authorize the app');
+        return setError('AuthSession failed, user did not authorize the app');
       }
 
       // Step #3 - when the user (successfully) authorized the app, we will receive a verification code.

--- a/with-twitter-auth/app/App.js
+++ b/with-twitter-auth/app/App.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import { AuthSession } from 'expo';
+import {
+  ActivityIndicator,
+  Button,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+const requestTokenURL = 'http://localhost:3000/request-token';
+const accessTokenURL = 'http://localhost:3000/access-token';
+
+export default class App extends React.Component {
+  state = {
+    loading: false,
+    error: undefined,
+    username: undefined,
+  };
+
+  componentDidMount() {
+    // This is the callback or redirect URL you need to whitelist in your Twitter app
+    console.log(`Callback URL: ${AuthSession.getRedirectUrl()}`);
+  }
+
+  _onLogout = () => {
+    this.setState({
+      loading: false,
+      error: undefined,
+      username: undefined,
+    });
+  }
+
+  _onLogin = async () => {
+    this.setState({ loading: true });
+
+    try {
+      // Step #1 - first we need to fetch a request token to start the browser-based authentication flow
+      const requestParams = toQueryString({ callback_url: AuthSession.getRedirectUrl() });
+      const requestTokens = await fetch(requestTokenURL + requestParams).then(res => res.json());
+
+      console.log('Request tokens fetched!', requestTokens);
+
+      // Step #2 - after we received the request tokens, we can start the auth session flow using these tokens
+      const authResponse = await AuthSession.startAsync({
+        authUrl: 'https://api.twitter.com/oauth/authenticate' + toQueryString(requestTokens),
+      });
+
+      console.log('Auth response received!', authResponse);
+
+      // Validate if the auth session response is successful
+      // Note, we still receive a `authResponse.type = 'success'`, thats why we need to check on the params itself
+      if (authResponse.params && authResponse.params.denied) {
+        return this.setState({ error: 'AuthSession was not successful, user did not authorize the app' });
+      }
+
+      // Step #3 - when the user (successfully) authorized the app, we will receive a verification code.
+      // With this code we can request an access token and finish the auth flow.
+      const accessParams = toQueryString({
+        oauth_token: requestTokens.oauth_token,
+        oauth_token_secret: requestTokens.oauth_token_secret,
+        oauth_verifier: authResponse.params.oauth_verifier,
+      });
+      const accessTokens = await fetch(accessTokenURL + accessParams).then(res => res.json());
+
+      console.log('Access tokens fetched!', accessTokens);
+
+      // Now let's store the username in our state to render it.
+      // You might want to store the `oauth_token` and `oauth_token_secret` for future use.
+      this.setState({ username: accessTokens.screen_name });
+    } catch (error) {
+      console.log('Something went wrong...', error);
+      this.setState({ error: error.message });
+    } finally {
+      this.setState({ loading: false });
+    }
+  }
+
+  render() {
+    const { loading, error, username } = this.state;
+
+    return (
+      <View style={styles.container}>
+        {username !== undefined ? (
+          <View>
+            <Text style={styles.title}>Hi {username}!</Text>
+            <Button title="Logout to try again" onPress={this._onLogout} />
+          </View>
+        ) : (
+          <View>
+            <Text style={styles.title}>Example: Twitter login</Text>
+            <Button title="Login with Twitter" onPress={this._onLogin} />
+          </View>
+        )}
+
+        {error !== undefined && (
+          <Text style={styles.error}>Error: {error}</Text>
+        )}
+
+        {loading && (
+          <View style={[StyleSheet.absoluteFill, styles.loading]}>
+            <ActivityIndicator color="#fff" size="large" animating />
+          </View>
+        )}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loading: {
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    textAlign: 'center',
+    marginTop: 40,
+  },
+  error: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 40,
+  },
+});
+
+/**
+ * Converts an object to a query string.
+ */
+function toQueryString(params) {
+  return '?' + Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}

--- a/with-twitter-auth/app/app.json
+++ b/with-twitter-auth/app/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "with-twitter-auth",
+    "version": "1.0.0",
+    "icon": "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/icon.png?raw=true",
+    "splash": {
+      "image": "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/splash.png?raw=true",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    }
+  }
+}

--- a/with-twitter-auth/app/babel.config.js
+++ b/with-twitter-auth/app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/with-twitter-auth/app/package.json
+++ b/with-twitter-auth/app/package.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "expo": "36.0.0",
+    "react": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz"
+  },
+  "devDependencies": {
+    "@babel/core": "7.0.0",
+    "babel-preset-expo": "8.0.0"
+  }
+}

--- a/with-twitter-auth/backend/index.js
+++ b/with-twitter-auth/backend/index.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const Twitter = require('twitter-lite');
+
+const app = express();
+const twitter = new Twitter({
+  consumer_key: '<API key>',
+  consumer_secret: '<API secret key>',
+});
+
+app.listen(3000, () => {
+  console.log('Twitter login backend listening to port 3000');
+});
+
+/**
+ * This endpoint returns the tokens to start browser-based authentication in your app.
+ * It's step #1 of the "Implementing Log in with Twitter" authentication flow.
+ *
+ * Requests must provide these query parameters:
+ *   - `callback_url`, the `AuthSession.getRedirectUrl()` for your app
+ *
+ * Responses will provide this structure:
+ *   - `oauth_token`, the request token to start the auth flow
+ *   - `oauth_token_secret`, the request token secret to start the auth flow
+ *   - `oauth_callback_confirmed`, if the callback is listed in your Twitter app settings.
+ *
+ * @see https://developer.twitter.com/en/docs/basics/authentication/guides/log-in-with-twitter
+ * @see https://developer.twitter.com/en/docs/basics/authentication/api-reference/request_token
+ * @see https://github.com/draftbit/twitter-lite#app-authentication-example
+ */
+app.get('/request-token', (req, res) => {
+  twitter.getRequestToken(req.query.callback_url)
+    .then(response => {
+      console.log('Fetched request token!', response);
+      res.json(response);
+    })
+    .catch(error => {
+      console.log('Could not fetch request token', error);
+      res.status(500).json({ message: error.message });
+    });
+});
+
+/**
+ * This endpoint "converts" both the request tokens and browser-based auth tokens to an access token.
+ * It's step #3 of the "Implementing Log in with Twitter" authentication flow.
+ *
+ * Requests must provide these query parameters:
+ *   - `oauth_token`, the request token that started the auth flow
+ *   - `oauth_token_secret`, the request token secret that started the auth flow
+ *   - `oauth_verifier`, the verification code received from browser-based auth flow
+ *
+ * Responses will provide this structure:
+ *   - `oauth_token`, the access token for API calls on behalf of the user
+ *   - `oauth_token_secret`, the access token secret for API calls on behalf of the user
+ *   - `user_id`, the id of the Twitter account that is authenticated
+ *   - `screen_name`, the username of the Twitter account that is authenticated
+ *
+ * @see https://developer.twitter.com/en/docs/basics/authentication/guides/log-in-with-twitter
+ * @see https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token
+ * @see https://github.com/draftbit/twitter-lite#app-authentication-example
+ */
+app.get('/access-token', (req, res) => {
+  const options = {
+    key: req.query.oauth_token,
+    secret: req.query.oauth_token_secret,
+    verifier: req.query.oauth_verifier,
+  };
+
+  twitter.getAccessToken(options)
+    .then(response => {
+      console.log('Access token fetched!', response);
+      res.json(response);
+    })
+    .catch(error => {
+      console.log('Could not fetch access token', error);
+      res.status(500).json({ message: error.message });
+    });
+});

--- a/with-twitter-auth/backend/package.json
+++ b/with-twitter-auth/backend/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "express": "^4.17.1",
+    "twitter-lite": "^0.9.4"
+  }
+}


### PR DESCRIPTION
Fixes #82 

Stuff I did after moving the Twitter auth example:

- **Added step-references to the [Login with Twitter guide](https://developer.twitter.com/en/docs/basics/authentication/guides/log-in-with-twitter)**
  That guide is useful. It contains a lot of flow visualizations and info a developer needs to know. By adding references to these steps, they can follow the code with the guide.

- **Rewrite the `WebBrowser` flow with `AuthSession`**
  Mostly because I think this is the preferred way, right? It avoids some heavier topics like deep linking. Or should I rewrite it to use [`AppAuth`](https://docs.expo.io/versions/latest/sdk/app-auth/)? Not sure what benefits you gain, I don't think Twitter allows you to authenticate without client secret?

- **Simplify the backend with [Twitter Lite](https://github.com/draftbit/twitter-lite)**
  The backend was kind of heavy to understand; a lot of things were happening there. By using Twitter Lite, we shift the focus mostly on the Expo implementation and provide additional resources to read about the backend part.

I can revert the backend change if you don't want to use libraries in these examples. But again, I think it would lower the barrier for developers to understand the basic principles behind the example.