### PR TITLE
refactor(with-custom-font): upgrade to expo sdk 37

### DIFF
--- a/with-custom-font/package.json
+++ b/with-custom-font/package.json
@@ -1,13 +1,14 @@
 {
   "dependencies": {
-    "expo": "~36.0.0",
-    "react": "~16.9.0",
-    "react-dom": "~16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
-    "react-native-web": "~0.11.7"
+    "expo": "^37.0.0",
+    "expo-font": "~8.1.0",
+    "react": "16.9.0",
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",
+    "react-native-web": "^0.11.7"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "babel-preset-expo": "~8.0.0"
+    "babel-preset-expo": "^8.1.0"
   }
 }

--- a/with-custom-font/package.json
+++ b/with-custom-font/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "^37.0.0",
-    "expo-font": "~8.1.0",
+    "expo": "37.0.7",
+    "expo-font": "8.1.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",
-    "react-native-web": "^0.11.7"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "babel-preset-expo": "^8.1.0"
+    "@babel/core": "7.9.0",
+    "babel-preset-expo": "8.1.0"
   }
 }


### PR DESCRIPTION
I also noticed `expo-font` was missing from the `package.json`, this adds that too. 😄 