### PR TITLE
refactor(with-sqlite): upgrade to sdk 37

### DIFF
--- a/with-sqlite/README.md
+++ b/with-sqlite/README.md
@@ -1,23 +1,25 @@
 # SQLite Example
 
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+</p>
+
 Example demonstrating use of the `SQLite` API in Expo.
 
 The app allows adding todo items, marking them as done, and deleting done items.
 `SQLite` features used include creating and opening databases, creating tables,
 inserting items, querying and displaying results, using prepared statements.
 
-You can also see this code in action **right in your browser** via [this snack](https://snack.expo.io/@charliecruzan/sqlite-example)!
+![Simulator Example](.gh-assets/1.png)
 
-#### Install & Build
+## 🚀 How to use
 
-- Clone this repository
+- Run `yarn` or `npm install`
+- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
 
-- Install dependencies by running `yarn install`
+## 📝 Notes
 
-- Install [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli/) by running `npm install -g expo-cli` (if not already installed globally on your machine)
-
-- Run the project locally by running `expo start`
-
-#### Screenshot
-
-<img src="./.gh-assets/1.png?raw=true" width="440" />
+- [Expo SQLite docs](https://docs.expo.io/versions/latest/sdk/sqlite/)

--- a/with-sqlite/package.json
+++ b/with-sqlite/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "36.0.0",
-    "expo-sqlite": "~8.0.0",
+    "expo": "37.0.7",
+    "expo-sqlite": "8.1.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "babel-preset-expo": "8.0.0"
+    "@babel/core": "7.9.0",
+    "babel-preset-expo": "8.1.0"
   }
 }


### PR DESCRIPTION
This also includes:

- A fix for using refs with functional components. Instead of this, it uses a `useForceUpdate` hook and the `key` property to force a rerender. Unfortuntately, refs doesn't work with functional components.
- Updated docs to reflect no support for web or snack. The docs states it has no web support, and the snack link failed. Also fixes #92