### PR TITLE
Use babel/core with babel-preset-expo in expo

### DIFF
--- a/with-animated-splash-screen/package.json
+++ b/with-animated-splash-screen/package.json
@@ -9,7 +9,6 @@
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-auth0/package.json
+++ b/with-auth0/package.json
@@ -7,7 +7,6 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-custom-font/package.json
+++ b/with-custom-font/package.json
@@ -8,7 +8,6 @@
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-electron/package.json
+++ b/with-electron/package.json
@@ -19,9 +19,9 @@
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
+    "@babel/core": "7.9.0",
     "@types/react": "16.9.34",
     "@types/react-native": "0.61.23",
-    "babel-preset-expo": "8.1.0",
     "typescript": "3.8.3"
   }
 }

--- a/with-facebook-auth/package.json
+++ b/with-facebook-auth/package.json
@@ -1,12 +1,10 @@
 {
-  "name": "with-facebook-auth",
-  "version": "0.0.0",
-  "description": "Hello Expo!",
-  "author": "support@expo.io",
-  "private": true,
   "dependencies": {
-    "expo": "^35.0.0",
+    "expo": "^37.0.7",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+  },
+  "devDependencies": {
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-facebook-auth/package.json
+++ b/with-facebook-auth/package.json
@@ -2,7 +2,9 @@
   "dependencies": {
     "expo": "^37.0.7",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
     "@babel/core": "7.9.0"

--- a/with-firebase-storage-upload/package.json
+++ b/with-firebase-storage-upload/package.json
@@ -7,6 +7,7 @@
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7",
     "uuid": "3.4.0"
   },
   "devDependencies": {

--- a/with-firebase-storage-upload/package.json
+++ b/with-firebase-storage-upload/package.json
@@ -1,16 +1,15 @@
 {
   "dependencies": {
-    "expo": "^36.0.0",
+    "expo": "^37.0.7",
     "expo-image-picker": "8.0.2",
     "expo-permissions": "8.0.0",
     "firebase": "7.8.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "uuid": "3.4.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "babel-preset-expo": "8.0.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-formdata-image-upload/app/package.json
+++ b/with-formdata-image-upload/app/package.json
@@ -5,7 +5,9 @@
     "expo-image-picker": "~7.0.0",
     "expo-permissions": "~7.0.0",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
     "@babel/core": "7.9.0"

--- a/with-formdata-image-upload/app/package.json
+++ b/with-formdata-image-upload/app/package.json
@@ -1,18 +1,13 @@
 {
-  "name": "with-formdata-image-upload",
-  "version": "1.0.0",
-  "description": "An example of how to upload image data with expo and fetch",
-  "author": "support@expo.io",
-  "private": true,
   "dependencies": {
-    "expo": "^35.0.0",
+    "expo": "^37.0.7",
     "expo-constants": "~7.0.0",
     "expo-image-picker": "~7.0.0",
     "expo-permissions": "~7.0.0",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
   },
   "devDependencies": {
-    "babel-preset-expo": "^7.0.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-gatsby/package.json
+++ b/with-gatsby/package.json
@@ -9,7 +9,7 @@
     "serve:web": "gatsby serve"
   },
   "dependencies": {
-    "expo": "^35.0.0",
+    "expo": "^37.0.7",
     "gatsby": "^2.17.6",
     "gatsby-image": "^2.2.30",
     "gatsby-plugin-manifest": "^2.2.25",
@@ -25,14 +25,14 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-helmet": "^5.2.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-web": "^0.11.7",
     "react-native-web-hooks": "^1.0.2"
   },
   "devDependencies": {
+    "@babel/core": "7.9.0",
     "@types/react": "^16.8.23",
     "@types/react-native": "^0.57.65",
-    "babel-preset-expo": "^7.1.0",
     "typescript": "^3.6.3"
   },
   "private": true

--- a/with-google-vision/package.json
+++ b/with-google-vision/package.json
@@ -1,14 +1,13 @@
 {
   "dependencies": {
-    "expo": "36.0.0",
+    "expo": "37.0.7",
     "expo-image-picker": "~8.0.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "babel-preset-expo": "8.0.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-icons/package.json
+++ b/with-icons/package.json
@@ -8,7 +8,6 @@
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-postpublish-hooks/package.json
+++ b/with-postpublish-hooks/package.json
@@ -6,6 +6,6 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
   },
   "devDependencies": {
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-postpublish-hooks/package.json
+++ b/with-postpublish-hooks/package.json
@@ -3,7 +3,9 @@
     "expo": "37.0.7",
     "expo-postpublish-slack-notify": "1.2.0",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
     "@babel/core": "7.9.0"

--- a/with-preact/package.json
+++ b/with-preact/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@babel/core": "7.9.0",
     "@expo/webpack-config": "0.12.0",
-    "babel-preset-expo": "8.1.0",
     "webpack-bundle-analyzer": "3.7.0"
   }
 }

--- a/with-react-router/package.json
+++ b/with-react-router/package.json
@@ -14,7 +14,6 @@
     "react-router-native": "5.1.2"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-socket-io/app/.babelrc
+++ b/with-socket-io/app/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/with-socket-io/app/babel.config.js
+++ b/with-socket-io/app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/with-socket-io/app/package.json
+++ b/with-socket-io/app/package.json
@@ -2,7 +2,9 @@
   "dependencies": {
     "expo": "^37.0.7",
     "react": "16.8.3",
+    "react-dom": "16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7",
     "socket.io-client": "^1.7.1"
   },
   "devDependencies": {

--- a/with-socket-io/app/package.json
+++ b/with-socket-io/app/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "socket-io-example",
-  "version": "0.0.0",
-  "description": "Hello Expo!",
-  "author": "support@expo.io",
-  "private": true,
   "dependencies": {
-    "expo": "^35.0.0",
+    "expo": "^37.0.7",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "socket.io-client": "^1.7.1"
+  },
+  "devDependencies": {
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-sqlite/package.json
+++ b/with-sqlite/package.json
@@ -8,7 +8,6 @@
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-storybook/package.json
+++ b/with-storybook/package.json
@@ -7,13 +7,13 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "expo": "^36.0.0",
+    "expo": "^37.0.7",
     "expo-constants": "~8.0.0",
     "expo-font": "~8.0.0",
     "expo-linear-gradient": "~8.0.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.1.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-web": "^0.11.7"
   },
   "devDependencies": {

--- a/with-twitter-auth/app/package.json
+++ b/with-twitter-auth/app/package.json
@@ -2,7 +2,9 @@
   "dependencies": {
     "expo": "37.0.7",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
     "@babel/core": "7.9.0"

--- a/with-twitter-auth/app/package.json
+++ b/with-twitter-auth/app/package.json
@@ -1,11 +1,10 @@
 {
   "dependencies": {
-    "expo": "36.0.0",
+    "expo": "37.0.7",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "babel-preset-expo": "8.0.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-typescript/package.json
+++ b/with-typescript/package.json
@@ -11,7 +11,6 @@
     "@types/react": "16.9.0",
     "@types/react-native": "0.61.23",
     "@babel/core": "7.9.0",
-    "babel-preset-expo": "8.1.0",
     "typescript": "3.8.3"
   }
 }

--- a/with-victory-native/package.json
+++ b/with-victory-native/package.json
@@ -4,7 +4,9 @@
     "expo-font": "~8.0.0",
     "lodash": "^4.17.10",
     "react": "16.9.0",
+    "react-dom": "16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7",
     "react-native-svg": "9.13.3",
     "victory-native": "^34.1.0"
   },

--- a/with-victory-native/package.json
+++ b/with-victory-native/package.json
@@ -1,11 +1,14 @@
 {
   "dependencies": {
-    "expo": "^36.0.0",
+    "expo": "^37.0.7",
     "expo-font": "~8.0.0",
     "lodash": "^4.17.10",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.1.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-svg": "9.13.3",
     "victory-native": "^34.1.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.0.0"
   }
 }

--- a/with-video-background/package.json
+++ b/with-video-background/package.json
@@ -1,14 +1,13 @@
 {
   "dependencies": {
-    "expo": "36.0.0",
+    "expo": "37.0.7",
     "expo-av": "~8.0.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-web": "0.11.7"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "babel-preset-expo": "8.0.0"
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-webbrowser-redirect/app/package.json
+++ b/with-webbrowser-redirect/app/package.json
@@ -1,8 +1,11 @@
 {
   "dependencies": {
-    "expo": "^35.0.0",
+    "expo": "37.0.7",
     "expo-web-browser": "~7.0.0",
-    "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz"
+    "react": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+  },
+  "devDependencies": {
+    "@babel/core": "7.9.0"
   }
 }

--- a/with-webbrowser-redirect/app/package.json
+++ b/with-webbrowser-redirect/app/package.json
@@ -3,7 +3,9 @@
     "expo": "37.0.7",
     "expo-web-browser": "~7.0.0",
     "react": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz"
+    "react-dom": "16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-web": "0.11.7"
   },
   "devDependencies": {
     "@babel/core": "7.9.0"


### PR DESCRIPTION
expo installs babel-preset-expo so we don't need to depend on it in every project. We do need to install babel/core tho.
Also add react-native-web to all projects