### PR TITLE
 Add `useNativeDriver` to with-video-background example

### DIFF
--- a/with-video-background/App.js
+++ b/with-video-background/App.js
@@ -21,7 +21,8 @@ export default function App() {
             onLoad={() => {
               // https://facebook.github.io/react-native/docs/animated#timing
               Animated.timing(opacity, {
-                toValue: 1
+                toValue: 1,
+                useNativeDriver: true,
               }).start();
             }}
             resizeMode="cover"


### PR DESCRIPTION
Fixes a TypeScript error when using this example with TypeScript, since it expects `useNativeDriver` to be defined. Also follows the example of [with-animated-splashscreen](https://github.com/expo/examples/blob/6bfc52cc335203e70d8d3fb8aa116992db4af6c8/with-animated-splash-screen/App.js#L55). 