### PR TITLE
Add @expo/webpack-config command to Readme

### DIFF
--- a/with-storybook/README.md
+++ b/with-storybook/README.md
@@ -36,6 +36,8 @@ This method runs your Expo components in a Storybook-React environment. This is 
   };
   ```
 
+- Run `yarn add -D @expo/webpack-config` to get the webpack-config added.
+
 - Run `yarn web` to try it out!
   - The example should open to `http://localhost:6006/`
 - You may also want to add `storybook-static` to your `.gitignore`


### PR DESCRIPTION
The @expo/webpack-config is needed by the webpack.config.js.