### PR TITLE
Updated EXPO SDK Version to 38.0.0

### DIFF
--- a/blank/package.json
+++ b/blank/package.json
@@ -3,7 +3,7 @@
     "expo": "37.0.11",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",
     "react-native-web": "0.11.7"
   },
   "devDependencies": {


### PR DESCRIPTION
In this commit, I have changed the Expo SDK version from 37.0.1 to 38.0.0

The Expo SDK 38 comes with React Native 0.62.2, it's better to migrate to take advantage of all those features.