### PR TITLE
docs: update latest docs link to expo repo

### DIFF
--- a/with-nextjs/README.md
+++ b/with-nextjs/README.md
@@ -11,7 +11,7 @@ Using Next.js with Expo will enable you to [server side render](https://nextjs.o
 
 ### ⚽️ Running in the browser
 
-For the most updated guide you should refer to the Expo docs: [Using Next.js](https://docs.expo.io/versions/latest/guides/using-nextjs/). Here are the [latest docs on master](https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md).
+For the most updated guide you should refer to the Expo docs: [Using Next.js](https://docs.expo.io/versions/latest/guides/using-nextjs/). Here are the [latest docs on master](https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md).
 
 In this approach you would be using SSR for web in your universal project. This is the recommended path because it gives you full access to the features of Expo and Next.js.
 


### PR DESCRIPTION
Update the link in the nextjs example `README.md` which points to the freshest expo next.js docs. The link currently specified,
`https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md`
Leads to '404 Page not Found'.

@EvanBacon - I noticed the link on [this blog post of yours](https://dev.to/evanbacon/next-js-expo-and-react-native-for-web-3kd9) has the same issue (`ctrl+f` "Here are the latest docs on master.") -- i.e. it points to `*/versions/unversioned*`.