### PR TITLE
Fix issue with incorrect Facebook redirectUri

### DIFF
--- a/with-facebook-auth/App.js
+++ b/with-facebook-auth/App.js
@@ -28,11 +28,7 @@ export default function App() {
       clientId: FB_APP_ID,
       scopes: ["public_profile", "user_likes"],
       // For usage in managed apps using the proxy
-      redirectUri: AuthSession.makeRedirectUri({
-        // For usage in bare and standalone
-        // Use your FBID here. The path MUST be `authorize`.
-        native: `fb${FB_APP_ID}://authorize`,
-      }),
+      redirectUri,
       extraParams: {
         // Use `popup` on web for a better experience
         display: Platform.select({ web: "popup" }),


### PR DESCRIPTION
This will close #194. This bug is easily reproducible by pulling down a fresh copy of the repo, running the with-facebook app in expo, following the setup steps, and then attempting a login. It will error with `No redirect URI in the params: No redirect present in the URI` because it's attempting to use `exp://...` url to redirect.

Correct redirectUri is already created above and includes the useProxy. https://github.com/hostr/examples/blob/481380b024cacaa770ff860c87d70fdb342f424b/with-facebook-auth/App.js#L18