### PR TITLE
[with-moti] web support

### DIFF
--- a/with-moti/package.json
+++ b/with-moti/package.json
@@ -1,15 +1,16 @@
 {
   "dependencies": {
     "expo": "~40.0.0",
-    "react": "16.13.1",
     "framer-motion": "^3.3.0",
     "moti": "^0.4.1",
+    "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
     "react-native-reanimated": "2.0.0-rc.0",
     "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "~7.9.0",
+    "@expo/webpack-config": "^0.12.58"
   }
 }

--- a/with-moti/webpack.config.js
+++ b/with-moti/webpack.config.js
@@ -1,0 +1,13 @@
+const createExpoWebpackConfigAsync = require('@expo/webpack-config')
+
+module.exports = async function (env, argv) {
+  const config = await createExpoWebpackConfigAsync(
+    {
+      ...env,
+      babel: { dangerouslyAddModulePathsToTranspile: ['moti'] },
+    },
+    argv
+  )
+
+  return config
+}


### PR DESCRIPTION
Add support for Expo Web in the Moti template.

Moti uses Reanimated v2 under the hood. Without transpiling it, the Reanimated Babel plugin is not applied on Web, causing Moti to break. This solves that.