### PR TITLE
Created tfjs camera example

### DIFF
--- a/with-tfjs-camera/App.js
+++ b/with-tfjs-camera/App.js
@@ -1,0 +1,21 @@
+import * as Permissions from "expo-permissions";
+import React from "react";
+
+import { LoadingView } from "./src/LoadingView";
+import { ModelView } from "./src/ModelView";
+import { useTensorFlowLoaded } from "./src/useTensorFlow";
+
+export default function App() {
+  const isLoaded = useTensorFlowLoaded();
+  const [status] = Permissions.usePermissions(Permissions.CAMERA, {
+    ask: true,
+  });
+  if (!(status || {}).granted) {
+    return <LoadingView>Camera permission is required to continue</LoadingView>;
+  }
+  if (!isLoaded) {
+    return <LoadingView>Loading TensorFlow</LoadingView>;
+  }
+
+  return <ModelView />;
+}

--- a/with-tfjs-camera/README.md
+++ b/with-tfjs-camera/README.md
@@ -1,0 +1,23 @@
+# TensorFlow Camera example
+
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+</p>
+
+Identify objects in real time using `@tensorflow/tfjs`, `expo-camera`, and `expo-gl` (for native acceleration).
+
+## 🚀 How to use
+
+> `npx create-react-native-app my-app -t with-tfjs-camera`
+
+- Run `expo start`, open on a native device (simulator, emulator, and browser are not supported).
+- You can swap out `@tensorflow-models/mobilenet` for another [TensorFlow model](https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md) to achieve different results.
+
+## 📝 Notes
+
+- [TFJS Expo API reference](https://js.tensorflow.org/api_react_native/latest/#Media-Camera)
+- [`@tensorflow/tfjs-react-native` package](https://www.npmjs.com/package/@tensorflow/tfjs-react-native)
+- [Expo Camera docs](https://docs.expo.io/versions/latest/sdk/camera/)

--- a/with-tfjs-camera/babel.config.js
+++ b/with-tfjs-camera/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/with-tfjs-camera/package.json
+++ b/with-tfjs-camera/package.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "@react-native-community/async-storage": "^1.12.1",
+    "@tensorflow-models/mobilenet": "^2.1.0",
+    "@tensorflow/tfjs": "^2.8.6",
+    "@tensorflow/tfjs-react-native": "^0.5.0",
+    "expo": "~40.0.0",
+    "expo-camera": "^10.0.0",
+    "expo-gl": "^10.1.0",
+    "expo-permissions": "^11.0.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
+    "react-native-fs": "^2.16.6",
+    "react-native-web": "~0.13.12"
+  },
+  "devDependencies": {
+    "@babel/core": "~7.9.0"
+  }
+}

--- a/with-tfjs-camera/src/LoadingView.js
+++ b/with-tfjs-camera/src/LoadingView.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+
+export function LoadingView({ children }) {
+  return (
+    <View style={styles.container}>
+      <View style={{ flexDirection: "row" }}>
+        <Text style={styles.text}>{children}</Text>
+        <ActivityIndicator />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: "center", alignItems: "center" },
+  text: { fontSize: 18, textAlign: "center", marginRight: 8 },
+});

--- a/with-tfjs-camera/src/ModelView.js
+++ b/with-tfjs-camera/src/ModelView.js
@@ -1,0 +1,102 @@
+import * as mobilenet from "@tensorflow-models/mobilenet";
+import { cameraWithTensors } from "@tensorflow/tfjs-react-native";
+import { Camera } from "expo-camera";
+import React from "react";
+import { StyleSheet, useWindowDimensions, View } from "react-native";
+import { LoadingView } from "./LoadingView";
+import { PredictionList } from "./PredictionList";
+
+import { useTensorFlowModel } from "./useTensorFlow";
+
+const TensorCamera = cameraWithTensors(Camera);
+
+export function ModelView() {
+  const model = useTensorFlowModel(mobilenet);
+  const [predictions, setPredictions] = React.useState([]);
+
+  if (!model) {
+    return <LoadingView>Loading TensorFlow model</LoadingView>;
+  }
+
+  return (
+    <View
+      style={{ flex: 1, backgroundColor: "black", justifyContent: "center" }}
+    >
+      <PredictionList predictions={predictions} />
+      <View style={{ borderRadius: 20, overflow: "hidden" }}>
+        <ModelCamera model={model} setPredictions={setPredictions} />
+      </View>
+    </View>
+  );
+}
+
+function ModelCamera({ model, setPredictions }) {
+  const raf = React.useRef(null);
+  const size = useWindowDimensions();
+
+  React.useEffect(() => {
+    return () => {
+      cancelAnimationFrame(raf.current);
+    };
+  }, []);
+
+  const onReady = React.useCallback(
+    (images) => {
+      const loop = async () => {
+        const nextImageTensor = images.next().value;
+        const predictions = await model.classify(nextImageTensor);
+        setPredictions(predictions);
+        raf.current = requestAnimationFrame(loop);
+      };
+      loop();
+    },
+    [setPredictions]
+  );
+
+  return React.useMemo(
+    () => (
+      <CustomTensorCamera
+        width={size.width}
+        style={styles.camera}
+        type={Camera.Constants.Type.back}
+        onReady={onReady}
+        autorender
+      />
+    ),
+    [onReady, size.width]
+  );
+}
+
+const textureSize = { width: 1080, height: 1920 };
+
+function CustomTensorCamera({ style, width, ...props }) {
+  const sizeStyle = React.useMemo(() => {
+    const ratio = width / textureSize.width;
+    const cameraWidth = textureSize.width * ratio;
+    const cameraHeight = textureSize.height * ratio;
+    return {
+      maxWidth: cameraWidth,
+      minWidth: cameraWidth,
+      maxHeight: cameraHeight,
+      minHeight: cameraHeight,
+    };
+  }, [width]);
+
+  return (
+    <TensorCamera
+      {...props}
+      style={[style, sizeStyle]}
+      cameraTextureWidth={textureSize.width}
+      cameraTextureHeight={textureSize.height}
+      resizeWidth={152}
+      resizeHeight={200}
+      resizeDepth={3}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  camera: {
+    zIndex: 0,
+  },
+});

--- a/with-tfjs-camera/src/PredictionList.js
+++ b/with-tfjs-camera/src/PredictionList.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+export function PredictionList({ predictions = [] }) {
+  return (
+    <View style={styles.container}>
+      {predictions.map((p, i) => (
+        <Text style={styles.text} key={`item-${i}`}>
+          {p.className}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+const margin = 24;
+
+const styles = StyleSheet.create({
+  container: {
+    zIndex: 100,
+    position: "absolute",
+    bottom: margin,
+    left: margin,
+    right: margin,
+    backgroundColor: "rgba(255,255,255,0.8)",
+    padding: 8,
+    borderRadius: 20,
+    alignItems: "center",
+  },
+  text: {
+    paddingVertical: 2,
+    fontSize: 20,
+  },
+});

--- a/with-tfjs-camera/src/useTensorFlow.js
+++ b/with-tfjs-camera/src/useTensorFlow.js
@@ -1,0 +1,40 @@
+import * as tf from "@tensorflow/tfjs";
+import React from "react";
+
+export function useTensorFlowModel(modelKind) {
+  const [model, setModel] = React.useState(null);
+
+  const isMounted = React.useRef(true);
+
+  React.useEffect(() => {
+    isMounted.current = true;
+    return () => (isMounted.current = false);
+  }, []);
+
+  React.useEffect(() => {
+    setModel(null);
+    modelKind.load().then((model) => {
+      if (isMounted.current) {
+        setModel(model);
+      }
+    });
+  }, [modelKind]);
+
+  return model;
+}
+
+export function useTensorFlowLoaded() {
+  const [isLoaded, setLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    let isMounted = true;
+    tf.ready().then(() => {
+      if (isMounted) {
+        setLoaded(true);
+      }
+    });
+    return () => (isMounted = false);
+  }, []);
+
+  return isLoaded;
+}


### PR DESCRIPTION
# Why

- The official native TensorFlow package uses Expo Camera and Expo GL https://js.tensorflow.org/api_react_native/latest/#Media-Camera. 
- CV is kewl.