### PR TITLE
[with-yarn-workspaces] use index.js as entry point

### DIFF
--- a/with-yarn-workspaces/apps/first-app/package.json
+++ b/with-yarn-workspaces/apps/first-app/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "__generated__/AppEntry.js",
+  "main": "index.js",
   "name": "@expo/first-app",
   "version": "1.0.0",
   "scripts": {

--- a/with-yarn-workspaces/apps/second-app/package.json
+++ b/with-yarn-workspaces/apps/second-app/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "__generated__/AppEntry.js",
+  "main": "index.js",
   "name": "@expo/second-app",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
Related to the bug fixed here: https://github.com/expo/expo/pull/13203. We need to use `index.js` as entry point instead of `__generated__/AppEntry.js`