### PR TITLE
[with-nextjs] upgrade to Next.js 11

### DIFF
--- a/with-nextjs/next.config.js
+++ b/with-nextjs/next.config.js
@@ -1,8 +1,10 @@
-// @generated: @expo/next-adapter@2.1.52
-// Learn more: https://docs.expo.io/guides/using-nextjs/
-
 const { withExpo } = require('@expo/next-adapter');
+const withPlugins = require('next-compose-plugins');
+const withTM = require('next-transpile-modules')(['react-native-web']);
 
-module.exports = withExpo({
-  projectRoot: __dirname,
-});
+const nextConfig = {};
+
+module.exports = withPlugins(
+  [withTM, [withExpo, { projectRoot: __dirname }]],
+  nextConfig
+);

--- a/with-nextjs/package.json
+++ b/with-nextjs/package.json
@@ -1,15 +1,17 @@
 {
   "dependencies": {
     "expo": "~42.0.0",
-    "next": "9.3.5",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
+    "next": "^11.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "^0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@expo/next-adapter": "~2.1.52"
+    "@babel/core": "^7.14.6",
+    "@expo/next-adapter": "^3.0.1",
+    "next-compose-plugins": "^2.2.1",
+    "next-transpile-modules": "^8.0.0"
   },
   "scripts": {
     "start": "next dev",


### PR DESCRIPTION
We added Next.js 11 and Webpack 5 support since `@expo/next-adapter@3.0.0` https://github.com/expo/expo-cli/pull/3586

This PR upgrades the example to Next.js 11