### PR TITLE
update expo.io links to expo.dev (except for auth.expo.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://expo.io/">
+  <a href="https://expo.dev/">
     <img alt="expo examples" height="128" src="./.gh-assets/banner.png">
     <h1 align="center">Expo Examples</h1>
   </a>
@@ -9,7 +9,7 @@
   <a aria-label="SDK version" href="https://www.npmjs.com/package/expo" target="_blank">
     <img alt="Expo SDK version" src="https://img.shields.io/npm/v/expo.svg?style=flat-square&label=SDK&labelColor=000000&color=4630EB">
   </a>
-  <a aria-label="Join our forums" href="https://forums.expo.io" target="_blank">
+  <a aria-label="Join our forums" href="https://forums.expo.dev" target="_blank">
     <img alt="" src="https://img.shields.io/badge/Ask%20Questions%20-blue.svg?style=flat-square&logo=discourse&logoWidth=15&labelColor=000000&color=4630EB">
   </a>
   <a aria-label="PRs Welcome" href="http://makeapullrequest.com" target="_blank">

--- a/blank/README.md
+++ b/blank/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <a href="https://docs.expo.io/workflow/web/">
+  <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a>
 </p>
@@ -34,11 +34,11 @@ This project can be run from a web browser or the Expo client app. You may find 
 
 ## Publishing
 
-- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.io/distribution/app-stores/).
-- Deploy the website using this guide: [Web deployment](https://docs.expo.io/distribution/publishing-websites/).
+- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.dev/distribution/app-stores/).
+- Deploy the website using this guide: [Web deployment](https://docs.expo.dev/distribution/publishing-websites/).
 
 ## 📝 Notes
 
-- Learn more about [Universal React](https://docs.expo.io/).
-- See what API and components are [available in the React runtimes](https://docs.expo.io/versions/latest/).
-- Find out more about developing apps and websites: [Guides](https://docs.expo.io/guides/).
+- Learn more about [Universal React](https://docs.expo.dev/).
+- See what API and components are [available in the React runtimes](https://docs.expo.dev/versions/latest/).
+- Find out more about developing apps and websites: [Guides](https://docs.expo.dev/guides/).

--- a/navigation/README.md
+++ b/navigation/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <a href="https://docs.expo.io/workflow/web/">
+  <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a>
 </p>
@@ -23,15 +23,15 @@
   - iOS: [Client iOS](https://itunes.apple.com/app/apple-store/id982107779)
   - Android: [Client Android](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=blankexample)
   - Web: Any web browser
-- When it's time to customize your runtime, refer to the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide!
+- When it's time to customize your runtime, refer to the ["Adding custom native code"](https://docs.expo.dev/workflow/customizing/) guide!
 
 ## Publishing
 
-- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.io/distribution/app-stores/).
-- Deploy the website using this guide: [Web deployment](https://docs.expo.io/distribution/publishing-websites/).
+- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.dev/distribution/app-stores/).
+- Deploy the website using this guide: [Web deployment](https://docs.expo.dev/distribution/publishing-websites/).
 
 ## 📝 Notes
 
-- Learn more about [Universal React](https://docs.expo.io/).
-- See what API and components are [available in the React runtimes](https://docs.expo.io/versions/latest/).
-- Find out more about developing apps and websites: [Official guides](https://docs.expo.io/guides/).
+- Learn more about [Universal React](https://docs.expo.dev/).
+- See what API and components are [available in the React runtimes](https://docs.expo.dev/versions/latest/).
+- Find out more about developing apps and websites: [Official guides](https://docs.expo.dev/guides/).

--- a/navigation/components/EditScreenInfo.tsx
+++ b/navigation/components/EditScreenInfo.tsx
@@ -45,7 +45,7 @@ export default function EditScreenInfo({ path }: { path: string }) {
 
 function handleHelpPress() {
   WebBrowser.openBrowserAsync(
-    'https://docs.expo.io/get-started/create-a-new-app/#opening-the-app-on-your-phonetablet'
+    'https://docs.expo.dev/get-started/create-a-new-app/#opening-the-app-on-your-phonetablet'
   );
 }
 

--- a/navigation/components/Themed.tsx
+++ b/navigation/components/Themed.tsx
@@ -1,6 +1,6 @@
 /**
  * Learn more about Light and Dark modes:
- * https://docs.expo.io/guides/color-schemes/
+ * https://docs.expo.dev/guides/color-schemes/
  */
 import * as React from 'react';
 import { Text as DefaultText, View as DefaultView } from 'react-native';

--- a/with-auth0/README.md
+++ b/with-auth0/README.md
@@ -15,7 +15,7 @@
 - Create your own app on [Auth0](https://auth0.com).
 - Add the `AuthSession` auth URL to `Allowed Callback URLs` on Auth0.
 - Open `App.js` and replace `auth0ClientId` and `auth0Domain` with your app settings.
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 #### AuthSession callback URL
 
@@ -23,7 +23,7 @@ The AuthSession helps you with browser authentication, without the need of an ad
 
 Each Expo user has it's own URL for different projects, the basic structure of this URL is `https://auth.expo.io/@your-username/your-expo-app-slug`. If you are signed in as `awesome-ppl`, and your app is called `meme-explorer`, your URL looks like `https://auth.expo.io/@awesome-ppl/meme-explorer`.
 
-> [Read more about AuthSession here](https://docs.expo.io/versions/latest/sdk/auth-session/)
+> [Read more about AuthSession here](https://docs.expo.dev/versions/latest/sdk/auth-session/)
 
 #### Auth0 app settings
 
@@ -33,5 +33,5 @@ Both the `auth0ClientId` and `auth0Domain` needs to match your Auth0 app setting
 
 ## 📝 Notes
 
-- [Expo AuthSession docs](https://docs.expo.io/versions/latest/sdk/auth-session/)
+- [Expo AuthSession docs](https://docs.expo.dev/versions/latest/sdk/auth-session/)
 - [Auth0 React/SPA quickstart guide](https://auth0.com/docs/quickstart/spa/react)

--- a/with-aws-storage-upload/README.md
+++ b/with-aws-storage-upload/README.md
@@ -18,4 +18,4 @@ Try it at https://exp.host/@ykbryan/aws-storage-upload
 ### Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.

--- a/with-camera/README.md
+++ b/with-camera/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <a href="https://docs.expo.io/workflow/web/">
+  <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a>
 </p>
@@ -29,4 +29,4 @@ This example shows how to take a picture and display it.
 
 ## 📝 Notes
 
-- Learn more about [Expo Camera](https://docs.expo.io/versions/latest/sdk/camera).
+- Learn more about [Expo Camera](https://docs.expo.dev/versions/latest/sdk/camera).

--- a/with-dev-client/README.md
+++ b/with-dev-client/README.md
@@ -32,8 +32,8 @@ To build the app with the dev client, just run `eas build --profile with-dev-cli
 
 > **Note**: the `with-dev-client` uses the **internal distribution** on **iOS**. That's why, you need to add your device to be able to install the built app. To do it, you can use `eas device:create`.
 
-**For more information about EAS, check out [documentation](https://docs.expo.io/eas/).**
+**For more information about EAS, check out [documentation](https://docs.expo.dev/eas/).**
 
 ## 📝 Notes
 
-- [Development Client docs](https://docs.expo.io/clients/introduction/)
+- [Development Client docs](https://docs.expo.dev/clients/introduction/)

--- a/with-dev-client/metro.config.js
+++ b/with-dev-client/metro.config.js
@@ -1,4 +1,4 @@
-// Learn more https://docs.expo.io/guides/customizing-metro
+// Learn more https://docs.expo.dev/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
 
 module.exports = getDefaultConfig(__dirname);

--- a/with-facebook-auth/README.md
+++ b/with-facebook-auth/README.md
@@ -1,15 +1,15 @@
 # Facebook Auth Example
 
-> Check out the [Auth with Facebook](https://docs.expo.io/guides/authentication/#facebook) docs.
+> Check out the [Auth with Facebook](https://docs.expo.dev/guides/authentication/#facebook) docs.
 
-Try it at https://expo.io/@community/with-facebook-auth
+Try it at https://expo.dev/@community/with-facebook-auth
 
 ## How to use
 
 ### Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 - Press "Open FB Auth" in the app and then check your logs. Take the `redirectUrl` that was logged and enter it into the "Valid OAuth redirect URIs" in your Facebook app configuration step below.
 
 ### Setting up the Facebook app
@@ -22,14 +22,14 @@ Try it at https://expo.io/@community/with-facebook-auth
 ## The idea behind the example
 
 Expo provides a
-[WebBrowser](https://docs.expo.io/versions/latest/sdk/webbrowser.html)
+[WebBrowser](https://docs.expo.dev/versions/latest/sdk/webbrowser.html)
 API that opens a SFSafariViewController or Chrome Custom Tab in a modal
 window. This provides a much better user experience than using a
 WebView, and it's more secure for your users because code cannot be
 injected into these browser windows. Additionally, they share cookies
 with the system browser, so there is no need to re-enter credentials if
 already authenticated. Expo also provides a wrapper around the `WebBrowser`
-API which is called [AuthSession](https://docs.expo.io/versions/latest/sdk/auth-session.html),
+API which is called [AuthSession](https://docs.expo.dev/versions/latest/sdk/auth-session.html),
 which makes setting up an authentication flow using `WebBrowser` dead simple.
 This example demonstrates how to use the `AuthSession` API to sign in to
 Facebook.

--- a/with-firebase-storage-upload/README.md
+++ b/with-firebase-storage-upload/README.md
@@ -12,11 +12,11 @@ This example demonstrates how you can upload images (and other files) to Firebas
 ## 🚀 How to use
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 - Take a new picture or upload one from your library
 - See the image being rendered from Firebase
 
 ## 📝 Notes
 
 - [Firebase Storage API](https://firebase.google.com/docs/storage/web/upload-files)
-- [Expo Firebase guide](https://docs.expo.io/versions/latest/guides/using-firebase/)
+- [Expo Firebase guide](https://docs.expo.dev/versions/latest/guides/using-firebase/)

--- a/with-formdata-image-upload/README.md
+++ b/with-formdata-image-upload/README.md
@@ -3,7 +3,7 @@
 ### Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ### Running the server
 

--- a/with-formik/README.md
+++ b/with-formik/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <a href="https://docs.expo.io/workflow/web/">
+  <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a>
 </p>

--- a/with-icons/README.md
+++ b/with-icons/README.md
@@ -1,4 +1,4 @@
-# [Icons Example](https://docs.expo.io/versions/latest/guides/icons/)
+# [Icons Example](https://docs.expo.dev/versions/latest/guides/icons/)
 
 <p>
   <!-- iOS -->
@@ -9,7 +9,7 @@
   <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
 </p>
 
-The package `@expo/vector-icons` enables you to use most popular icon sets in a universal app. For more information please refer to the docs: [Expo Icons](https://docs.expo.io/versions/latest/guides/icons/).
+The package `@expo/vector-icons` enables you to use most popular icon sets in a universal app. For more information please refer to the docs: [Expo Icons](https://docs.expo.dev/versions/latest/guides/icons/).
 
 ## 🚀 How to use
 
@@ -40,4 +40,4 @@ import {
 ## 📝 Notes
 
 - [Icon directory](https://expo.github.io/vector-icons/)
-- [`@expo/vector-icons` documentation](https://docs.expo.io/versions/latest/guides/icons/)
+- [`@expo/vector-icons` documentation](https://docs.expo.dev/versions/latest/guides/icons/)

--- a/with-magic/README.md
+++ b/with-magic/README.md
@@ -12,7 +12,7 @@
 - Install with `yarn` or `npm install`.
 - Create your own app on [Magic.link](https://magic.link).
 - Open `App.js` and replace `MAGIC_KEY` with your publishable key.
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 

--- a/with-maps/README.md
+++ b/with-maps/README.md
@@ -28,10 +28,10 @@ This project can be run from Expo client app. You may find that you want to add 
 
 ## Publishing
 
-- Configure your app to be able to use react-native-maps in production using this guide : [MapView configuration](https://docs.expo.io/versions/v38.0.0/sdk/map-view/#configuration)
-- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.io/distribution/app-stores/).
+- Configure your app to be able to use react-native-maps in production using this guide : [MapView configuration](https://docs.expo.dev/versions/v38.0.0/sdk/map-view/#configuration)
+- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.dev/distribution/app-stores/).
 
 ## 📝 Notes
 
-- Learn more about [MapView](https://docs.expo.io/versions/v38.0.0/sdk/map-view).
+- Learn more about [MapView](https://docs.expo.dev/versions/v38.0.0/sdk/map-view).
 - Learn more about [react-native-maps](https://github.com/react-native-community/react-native-maps).

--- a/with-moti/README.md
+++ b/with-moti/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <!-- <a href="https://docs.expo.io/workflow/web/">
+  <!-- <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a> -->
 </p>
@@ -26,7 +26,7 @@
   - iOS: [Client iOS](https://itunes.apple.com/app/apple-store/id982107779)
   - Android: [Client Android](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=blankexample)
 
-> 💡 This demo uses **experimental** Reanimated 2 support in Expo. [Learn more](https://docs.expo.io/versions/latest/sdk/reanimated/#experimental-support-for-v2).
+> 💡 This demo uses **experimental** Reanimated 2 support in Expo. [Learn more](https://docs.expo.dev/versions/latest/sdk/reanimated/#experimental-support-for-v2).
 
 ### TypeScript
 
@@ -35,7 +35,7 @@ Moti is built with TypeScript and has first-class support. Here's how to add TS 
 - Rename `App.js` ➜ `App.tsx`
 - Run `expo start` -- TypeScript will be automatically configured.
 
-> 💡 Learn more about [TypeScript in Expo](https://docs.expo.io/guides/typescript/)
+> 💡 Learn more about [TypeScript in Expo](https://docs.expo.dev/guides/typescript/)
 
 ### Adding Native Code
 
@@ -44,15 +44,15 @@ This project can be run from a web browser or the Expo client app. You may find 
 - Run `expo eject` to create the native projects.
 - You can still run your project in the web browser or Expo client, you just won't be able to access any new native modules you add.
 
-> 💡 Learn more about [native code in Expo](https://docs.expo.io/workflow/customizing/)
+> 💡 Learn more about [native code in Expo](https://docs.expo.dev/workflow/customizing/)
 
 ### Publishing
 
-- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.io/distribution/app-stores/).
+- Deploy the native app to the App store and Play store using this guide: [Deployment](https://docs.expo.dev/distribution/app-stores/).
 
 ## 📝 Notes
 
-- [Expo Reanimated docs](https://docs.expo.io/versions/latest/sdk/reanimated)
+- [Expo Reanimated docs](https://docs.expo.dev/versions/latest/sdk/reanimated)
 - [Moti docs](https://moti.fyi/)
 - [Reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/2.0.0-alpha.8/)
 - Keep up with the creator of Moti [Fernando Rojo](https://twitter.com/FernandoTheRojo) for updates.

--- a/with-nextjs/README.md
+++ b/with-nextjs/README.md
@@ -11,7 +11,7 @@ Using Next.js with Expo will enable you to [server side render](https://nextjs.o
 
 ### ⚽️ Running in the browser
 
-For the most updated guide you should refer to the Expo docs: [Using Next.js](https://docs.expo.io/versions/latest/guides/using-nextjs/). Here are the [latest docs on master](https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md).
+For the most updated guide you should refer to the Expo docs: [Using Next.js](https://docs.expo.dev/versions/latest/guides/using-nextjs/). Here are the [latest docs on master](https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md).
 
 In this approach you would be using SSR for web in your universal project. This is the recommended path because it gives you full access to the features of Expo and Next.js.
 

--- a/with-nextjs/babel.config.js
+++ b/with-nextjs/babel.config.js
@@ -1,4 +1,4 @@
 // @generated: @expo/next-adapter@2.1.52
-// Learn more: https://docs.expo.io/guides/using-nextjs/
+// Learn more: https://docs.expo.dev/guides/using-nextjs/
 
 module.exports = { presets: ['@expo/next-adapter/babel'] };

--- a/with-postpublish-hooks/README.md
+++ b/with-postpublish-hooks/README.md
@@ -18,4 +18,4 @@ It's common to need to perform a set of tasks once you publish an update to your
 #### Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.

--- a/with-react-three-fiber/README.md
+++ b/with-react-three-fiber/README.md
@@ -16,7 +16,7 @@ Create Three.js projects using React components and props!
 > `npx create-react-native-app my-app -t with-react-three-fiber`
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 

--- a/with-reanimated2/README.md
+++ b/with-reanimated2/README.md
@@ -15,7 +15,7 @@ Experiment with Reanimated 2 (rc) in SDK 40.
 > `npx create-react-native-app my-app -t with-reanimated2`
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 

--- a/with-socket-io/README.md
+++ b/with-socket-io/README.md
@@ -5,7 +5,7 @@
 ## Running the app
 
 - Run `yarn` or `npm install`
-- Open `app` with [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Open `app` with [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ### Running the server (optional)
 

--- a/with-splash-screen/README.md
+++ b/with-splash-screen/README.md
@@ -14,11 +14,11 @@ This example shows you how to create an animated splash screen for your app. It 
 ## 🚀 How to use
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 - Wait until the app is built and downloaded. Press "run again" to reload the app and splash screen.
 
 ## 📝 Notes
 
-- [Expo AppLoading docs](https://docs.expo.io/versions/latest/sdk/app-loading/)
-- [Expo Assets guide](https://docs.expo.io/versions/latest/guides/assets/)
-- [Expo Splash Screen guide](https://docs.expo.io/versions/latest/guides/splash-screens/)
+- [Expo AppLoading docs](https://docs.expo.dev/versions/latest/sdk/app-loading/)
+- [Expo Assets guide](https://docs.expo.dev/versions/latest/guides/assets/)
+- [Expo Splash Screen guide](https://docs.expo.dev/versions/latest/guides/splash-screens/)

--- a/with-sqlite/README.md
+++ b/with-sqlite/README.md
@@ -18,8 +18,8 @@ inserting items, querying and displaying results, using prepared statements.
 ## 🚀 How to use
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 
-- [Expo SQLite docs](https://docs.expo.io/versions/latest/sdk/sqlite/)
+- [Expo SQLite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/)

--- a/with-styled-components/README.md
+++ b/with-styled-components/README.md
@@ -12,7 +12,7 @@
 ## 🚀 How to use
 
 - Install with `yarn` or `npm install`.
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 

--- a/with-svg/README.md
+++ b/with-svg/README.md
@@ -7,7 +7,7 @@ Import SVG files directly as React components.
 ### Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ### Setup
 

--- a/with-tfjs-camera/README.md
+++ b/with-tfjs-camera/README.md
@@ -20,4 +20,4 @@ Identify objects in real time using `@tensorflow/tfjs`, `expo-camera`, and `expo
 
 - [TFJS Expo API reference](https://js.tensorflow.org/api_react_native/latest/#Media-Camera)
 - [`@tensorflow/tfjs-react-native` package](https://www.npmjs.com/package/@tensorflow/tfjs-react-native)
-- [Expo Camera docs](https://docs.expo.io/versions/latest/sdk/camera/)
+- [Expo Camera docs](https://docs.expo.dev/versions/latest/sdk/camera/)

--- a/with-three/README.md
+++ b/with-three/README.md
@@ -12,9 +12,9 @@
 ## 🚀 How to use
 
 - Install with `yarn` or `npm install`.
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 
-- [Expo GL docs](https://docs.expo.io/versions/latest/sdk/gl-view/)
+- [Expo GL docs](https://docs.expo.dev/versions/latest/sdk/gl-view/)
 - [Three.js docs](https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene)

--- a/with-twitter-auth/README.md
+++ b/with-twitter-auth/README.md
@@ -30,7 +30,7 @@ The purpose of the backend is to store the Twitter API keys without leaking this
 
 - Install with `yarn` or `npm install`
 - Open `App.js` and replace `requestTokenURL` and `accessTokenURL` with your backend URLs
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out
 
 ### 📁 File Structure
 
@@ -42,7 +42,7 @@ Expo Twitter Auth
 
 ## 📝 Notes
 
-- [Expo AuthSession docs](https://docs.expo.io/versions/latest/sdk/auth-session/)
+- [Expo AuthSession docs](https://docs.expo.dev/versions/latest/sdk/auth-session/)
 - [Twitter Lite docs](https://github.com/draftbit/twitter-lite)
 - [Login with Twitter guide](https://developer.twitter.com/en/docs/basics/authentication/guides/log-in-with-twitter)
 - [Twitter authentication best practices](https://developer.twitter.com/en/docs/basics/authentication/guides/authentication-best-practices)
@@ -53,4 +53,4 @@ The AuthSession helps you with browser authentication, without the need of an ad
 
 Each Expo user has it's own URL for different projects, the basic structure of this URL is `https://auth.expo.io/@your-username/your-expo-app-slug`. If you are signed in as `awesome-ppl`, and your app is called `meme-explorer`, your URL looks like `https://auth.expo.io/@awesome-ppl/meme-explorer`.
 
-> [Read more about AuthSession here](https://docs.expo.io/versions/latest/sdk/auth-session/)
+> [Read more about AuthSession here](https://docs.expo.dev/versions/latest/sdk/auth-session/)

--- a/with-typescript/README.md
+++ b/with-typescript/README.md
@@ -33,4 +33,4 @@ TypeScript is a superset of JavaScript which gives you static types and powerful
 
 ## 📝 Notes
 
-- [Expo TypeScript guide](https://docs.expo.io/versions/latest/guides/typescript/)
+- [Expo TypeScript guide](https://docs.expo.dev/versions/latest/guides/typescript/)

--- a/with-victory-native/README.md
+++ b/with-victory-native/README.md
@@ -5,7 +5,7 @@
 ## Running the app
 
 - Run `yarn` or `npm install`
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), to try it out!
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), to try it out!
 
 ## The idea behind the example
 

--- a/with-video-background/README.md
+++ b/with-video-background/README.md
@@ -6,7 +6,7 @@ Video backgrounds are common in mobile apps. This shows you how to do it univers
 
 - Install: `yarn`
 
-- [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli/): `npm install -g expo-cli` (if not already installed globally on your machine)
+- [Expo CLI](https://docs.expo.dev/versions/latest/workflow/expo-cli/): `npm install -g expo-cli` (if not already installed globally on your machine)
 
 - Run Project Locally: `expo start`
 

--- a/with-webbrowser-redirect/README.md
+++ b/with-webbrowser-redirect/README.md
@@ -3,7 +3,7 @@
 ### Running the app
 
 - Run `yarn` or `npm install`
-- Open `app` with [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Open `app` with [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## The idea behind the example
 

--- a/with-yarn-workspaces/README.md
+++ b/with-yarn-workspaces/README.md
@@ -10,7 +10,7 @@
     <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   </a>
   <!-- Web -->
-  <a href="https://docs.expo.io/workflow/web/">
+  <a href="https://docs.expo.dev/workflow/web/">
     <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
   </a>
 </p>
@@ -49,4 +49,4 @@ Please note that there are currently a few of quirks with using monorepos with E
 
 1. Expo SDK packages should be added to the `"symlinks"` list in `package.json`.
 2. `index.js` is used instead of expo-yarn-workspaces' default `__generated__/AppEntry.js` because React Native's `bundle` command does not respect the `"main"` field in `package.json`, so we can't use it here.
-3. `metro.config.js` must extend `expo-yarn-workspaces`'s default configuration. This automatically extends `@expo/metro-config`. [Learn about customizing metro.config.js](https://docs.expo.io/guides/customizing-metro/).
+3. `metro.config.js` must extend `expo-yarn-workspaces`'s default configuration. This automatically extends `@expo/metro-config`. [Learn about customizing metro.config.js](https://docs.expo.dev/guides/customizing-metro/).

--- a/with-zustand/README.md
+++ b/with-zustand/README.md
@@ -15,7 +15,7 @@ This example implements a basic store and list using the `zustand` library.
 ## 🚀 How to use
 
 - Install with `yarn` or `npm install`.
-- Run [`expo start`](https://docs.expo.io/versions/latest/workflow/expo-cli/), try it out.
+- Run [`expo start`](https://docs.expo.dev/versions/latest/workflow/expo-cli/), try it out.
 
 ## 📝 Notes
 


### PR DESCRIPTION
We just updated our public-facing domains, so we should update our code to reflect this.