### PR TITLE
[auth0] Upgrade to Expo SDK 43

### DIFF
--- a/with-auth0/package.json
+++ b/with-auth0/package.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-auth-session": "~3.3.0",
-    "expo-random": "~11.1.2",
+    "expo": "^43.0.0",
+    "expo-auth-session": "~3.4.2",
+    "expo-random": "~12.0.0",
     "jwt-decode": "2.2.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Works well, it only has a warning about the missing scheme. But in this case that makes sense since we want people to use their own instead of copying blindly.

![Screenshot 2021-10-23 at 00 17 11](https://user-images.githubusercontent.com/1203991/138528885-718ae59c-5be2-49c6-8eaa-6cfb1b9ddc2b.png)
