### PR TITLE
[drawer-navigation] Upgrade to Expo SDK 43 and React Navigation 6

### DIFF
--- a/with-drawer-navigation/package.json
+++ b/with-drawer-navigation/package.json
@@ -1,19 +1,19 @@
 {
   "dependencies": {
     "@react-native-community/masked-view": "0.1.10",
-    "@react-navigation/drawer": "~5.10.7",
-    "@react-navigation/native": "~5.6.1",
-    "expo": "~42.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+    "@react-navigation/drawer": "^6.1.8",
+    "@react-navigation/native": "^6.0.6",
+    "expo": "^43.0.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-safe-area-context": "3.2.0",
-    "react-native-screens": "~3.4.0",
-    "react-native-web": "~0.13.12"
+    "react-native-safe-area-context": "3.3.2",
+    "react-native-screens": "~3.8.0",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
“Be the git diff that you wish to see in the world.”
― Mahatma Gandhi