### PR TITLE
[electron] Upgrade to Expo SDK 43

### DIFF
--- a/with-electron/package.json
+++ b/with-electron/package.json
@@ -10,20 +10,20 @@
   },
   "dependencies": {
     "@expo/electron-adapter": "~0.0.3",
-    "@expo/webpack-config": "~0.12.63",
+    "@expo/webpack-config": "^0.16.2",
     "electron": "6.1.10",
-    "expo": "~42.0.0",
-    "expo-linear-gradient": "~9.2.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-linear-gradient": "~10.0.3",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@types/react": "~16.9.35",
-    "@types/react-dom": "~16.9.8",
-    "@types/react-native": "~0.63.2",
-    "typescript": "~4.0.0"
+    "@babel/core": "^7.12.9",
+    "@types/react": "~17.0.21",
+    "@types/react-dom": "~17.0.9",
+    "@types/react-native": "~0.64.12",
+    "typescript": "~4.3.5"
   }
 }


### PR DESCRIPTION
I chickened out on upgrading electron as well. We might need to do that eventually.
![Screenshot 2021-10-23 at 01 52 34](https://user-images.githubusercontent.com/1203991/138534153-f9c93f16-b936-408e-ae06-fcd3313f99e4.png)
