### PR TITLE
[facebook-auth] Upgrade to Expo SDK 43

### DIFF
--- a/with-facebook-auth/package.json
+++ b/with-facebook-auth/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-auth-session": "~3.3.1",
-    "expo-random": "~11.2.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-auth-session": "~3.4.2",
+    "expo-random": "~12.0.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
I wonder when we have to rename this to `with-metaverse-auth`