### PR TITLE
[formdata-image-upload] Upgrade to Expo SDK 43

### DIFF
--- a/with-formdata-image-upload/App.js
+++ b/with-formdata-image-upload/App.js
@@ -1,14 +1,5 @@
 import * as React from "react";
-import {
-  ActivityIndicator,
-  Button,
-  Image,
-  Share,
-  StatusBar,
-  Text,
-  View,
-} from "react-native";
-import * as Clipboard from "expo-clipboard";
+import { ActivityIndicator, Button, Image, StatusBar, Text, View } from "react-native";
 import * as ImagePicker from "expo-image-picker";
 
 export default class App extends React.Component {
@@ -42,7 +33,7 @@ export default class App extends React.Component {
 
   _maybeRenderUploadingIndicator = () => {
     if (this.state.uploading) {
-      return <ActivityIndicator animating size="large" />;
+      return <ActivityIndicator animating size="large" color="#0000ee" />;
     }
   };
 
@@ -92,29 +83,13 @@ export default class App extends React.Component {
             />
           </View>
 
-          <Text
-            onPress={this._copyToClipboard}
-            onLongPress={this._share}
+          <Image
             style={{ paddingVertical: 10, paddingHorizontal: 10 }}
-          >
-            {this.state.image}
-          </Text>
+            source={{ uri: this.state.image }}
+          />
         </View>
       );
     }
-  };
-
-  _share = () => {
-    Share.share({
-      message: this.state.image,
-      title: "Check out this photo",
-      url: this.state.image,
-    });
-  };
-
-  _copyToClipboard = () => {
-    Clipboard.setString(this.state.image);
-    alert("Copied image URL to clipboard");
   };
 
   _askPermission = async (failureMessage) => {
@@ -166,7 +141,7 @@ export default class App extends React.Component {
         uploadResponse = await uploadImageAsync(pickerResult.uri);
         uploadResult = await uploadResponse.json();
         console.log({ uploadResult });
-        this.setState({ image: uploadResult.location });
+        this.setState({ image: uploadResult.files.photo });
       }
     } catch (e) {
       console.log({ uploadResponse });
@@ -180,8 +155,7 @@ export default class App extends React.Component {
 }
 
 async function uploadImageAsync(uri) {
-  let apiUrl =
-    "https://file-upload-example-backend-dkhqoilqqn.vercel.app/upload";
+  let apiUrl = "https://httpbin.org/post";
 
   // Note:
   // Uncomment this if you want to experiment with local server

--- a/with-formdata-image-upload/package.json
+++ b/with-formdata-image-upload/package.json
@@ -1,15 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-clipboard": "~1.1.0",
-    "expo-constants": "~11.0.1",
-    "expo-image-picker": "~10.2.2",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-constants": "~12.1.3",
+    "expo-image-picker": "~11.0.3",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Had to change the API endpoint, since that was no longer found. And sharing/copying huge base64 doesn't work that well, so the share and copy to clipboard are also gone.