### PR TITLE
[formik] Upgrade to Expo SDK 43

### DIFF
--- a/with-formik/package.json
+++ b/with-formik/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
+    "expo": "^43.0.0",
     "formik": "~2.2.9",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12",
-    "yup": "0.32.8"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1",
+    "yup": "0.32.11"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Seems pretty stable, still on the same formik + yup minor/major versions