### PR TITLE
[gatsby] Upgrade to Expo SDK 43

### DIFF
--- a/with-gatsby/package.json
+++ b/with-gatsby/package.json
@@ -9,7 +9,7 @@
     "serve:web": "gatsby serve"
   },
   "dependencies": {
-    "expo": "~42.0.0",
+    "expo": "^43.0.0",
     "gatsby": "^2.17.6",
     "gatsby-image": "^2.2.30",
     "gatsby-plugin-manifest": "^2.2.25",
@@ -21,19 +21,19 @@
     "gatsby-plugin-webpack-bundle-analyzer": "^1.0.5",
     "gatsby-source-filesystem": "^2.1.35",
     "gatsby-transformer-sharp": "^2.3.1",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
     "react-helmet": "^5.2.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1",
     "react-native-web-hooks": "~3.0.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@types/react": "~16.9.35",
-    "@types/react-dom": "~16.9.8",
-    "@types/react-native": "~0.63.2",
-    "typescript": "~4.0.0"
+    "@babel/core": "^7.12.9",
+    "@types/react": "~17.0.21",
+    "@types/react-dom": "~17.0.9",
+    "@types/react-native": "~0.64.12",
+    "typescript": "~4.3.5"
   },
   "private": true
 }


### PR DESCRIPTION
I did not look into upgrading Gatsby here but seems like we should.