### PR TITLE
[moti] Upgrade to Expo SDK 43 and Moti 0.16

### DIFF
--- a/with-moti/package.json
+++ b/with-moti/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "expo": "^43.0.0",
-    "moti": "^0.11.0",
+    "moti": "^0.16.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.2",

--- a/with-moti/package.json
+++ b/with-moti/package.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
+    "expo": "^43.0.0",
     "moti": "^0.11.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@expo/webpack-config": "~0.12.82"
+    "@babel/core": "^7.12.9",
+    "@expo/webpack-config": "^0.16.2"
   }
 }


### PR DESCRIPTION
Web seems a _little_ bit off, but not sure why. Instead of shrinking + fading away, it grows first (cc @nandorojo). Native does work great.