### PR TITLE
[nextjs] Upgrade to Expo SDK 43

### DIFF
--- a/with-nextjs/package.json
+++ b/with-nextjs/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
+    "expo": "^43.0.0",
     "next": "9.3.5",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
+    "@babel/core": "^7.12.9",
     "@expo/next-adapter": "~2.1.52"
   },
   "scripts": {


### PR DESCRIPTION
Did not upgrade to Next 10 or 11, both seem to fail on some babel-specific things.