### PR TITLE
[react-router] Upgrade to Expo SDK 43 and bump React Router

### DIFF
--- a/with-react-router/README.md
+++ b/with-react-router/README.md
@@ -1,6 +1,10 @@
 # [React Router Example](https://reacttraining.com/react-router/web/guides/quick-start)
 
 <p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
   <!-- Web -->
   <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
 </p>

--- a/with-react-router/package.json
+++ b/with-react-router/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12",
+    "expo": "^43.0.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1",
     "react-router-dom": "5.1.2",
     "react-router-native": "5.1.2"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }

--- a/with-react-router/package.json
+++ b/with-react-router/package.json
@@ -5,8 +5,8 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-web": "0.17.1",
-    "react-router-dom": "5.1.2",
-    "react-router-native": "5.1.2"
+    "react-router-dom": "5.3.0",
+    "react-router-native": "5.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"


### PR DESCRIPTION
Also added Android and iOS support, since we actually do in this example.