### PR TITLE
[react-three-fiber] Upgrade to Expo SDK 43

### DIFF
--- a/with-react-three-fiber/package.json
+++ b/with-react-three-fiber/package.json
@@ -1,16 +1,16 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-gl": "~10.4.1",
+    "expo": "^43.0.0",
+    "expo-gl": "~11.0.3",
     "expo-three": "~5.7.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1",
     "react-three-fiber": "^5.3.19",
     "three": "^0.122.0"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
[Can't upgrade react three fiber because of this issue](https://github.com/pmndrs/react-three-fiber/issues/1506). TL;DR; they shipped a version with a `react-native` target/entry file without that file actually existing.

![image](https://user-images.githubusercontent.com/1203991/138598345-9f9fc146-c310-439a-a9b5-57650580d083.png)
