### PR TITLE
[splash-screen] Upgrade to Expo SDK 43

### DIFF
--- a/with-splash-screen/package.json
+++ b/with-splash-screen/package.json
@@ -1,17 +1,17 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-app-loading": "~1.1.2",
-    "expo-asset": "~8.3.2",
-    "expo-constants": "~11.0.1",
-    "expo-splash-screen": "~0.11.2",
-    "expo-updates": "~0.8.1",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-app-loading": "~1.2.1",
+    "expo-asset": "~8.4.3",
+    "expo-constants": "~12.1.3",
+    "expo-splash-screen": "~0.13.4",
+    "expo-updates": "~0.10.5",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Luckily this one is with a screen, without it the splash would look more like:
![image](https://media.giphy.com/media/semLgqWI3U3qU/giphy-downsized.gif)
