### PR TITLE
[svg] Upgrade to Expo SDK 43

### DIFF
--- a/with-svg/package.json
+++ b/with-svg/package.json
@@ -1,17 +1,17 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+    "expo": "^43.0.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
     "react-native-svg": "12.1.1",
     "react-native-svg-transformer": "^0.14.3",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
+    "@babel/core": "^7.12.9",
     "@expo/metro-config": "^0.1.57",
-    "@expo/webpack-config": "~0.12.63",
+    "@expo/webpack-config": "^0.16.2",
     "@svgr/webpack": "^5.5.0"
   }
 }


### PR DESCRIPTION
SVGs are used as [inline images for 97.05% of all usage](https://css-tricks.com/random-interesting-facts-htmlsvg-usage/#svg) 