### PR TITLE
[tab-navigation] Upgrade to Expo SDK 43 and React Navigation 6

### DIFF
--- a/with-tab-navigation/App.js
+++ b/with-tab-navigation/App.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Text, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
@@ -25,9 +26,15 @@ export default function App() {
   return (
     <NavigationContainer>
       <Tab.Navigator>
-        <Tab.Screen name="Home" component={HomeScreen} />
-        <Tab.Screen name="Settings" component={SettingsScreen} />
+        <Tab.Screen name="Home" component={HomeScreen} options={{ tabBarIcon: makeIconRender('home') }} />
+        <Tab.Screen name="Settings" component={SettingsScreen} options={{ tabBarIcon: makeIconRender('cog') }} />
       </Tab.Navigator>
     </NavigationContainer>
+  );
+}
+
+function makeIconRender(name) {
+  return ({ color, size }) => (
+    <MaterialCommunityIcons name={name} color={color} size={size} />
   );
 }

--- a/with-tab-navigation/package.json
+++ b/with-tab-navigation/package.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
+    "@expo/vector-icons": "^12.0.0",
     "@react-native-community/masked-view": "0.1.10",
-    "@react-navigation/bottom-tabs": "~5.11.7",
-    "@react-navigation/native": "~5.9.2",
+    "@react-navigation/bottom-tabs": "~6.0.9",
+    "@react-navigation/native": "~6.0.6",
     "expo": "^43.0.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/with-tab-navigation/package.json
+++ b/with-tab-navigation/package.json
@@ -3,18 +3,18 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "~5.11.7",
     "@react-navigation/native": "~5.9.2",
-    "expo": "~42.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+    "expo": "^43.0.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-safe-area-context": "3.2.0",
-    "react-native-screens": "~3.4.0",
-    "react-native-web": "~0.13.12"
+    "react-native-safe-area-context": "3.3.2",
+    "react-native-screens": "~3.8.0",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   },
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
Also added some default tab icons, it looked a bit sad without them.