### PR TITLE
[three] Upgrade to Expo SDK 43

### DIFF
--- a/with-three/package.json
+++ b/with-three/package.json
@@ -1,19 +1,19 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-gl": "~10.4.1",
+    "expo": "^43.0.0",
+    "expo-gl": "~11.0.3",
     "expo-three": "~5.7.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1",
     "three": "^0.122.0"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@types/react": "~16.9.35",
-    "@types/react-dom": "~16.9.8",
-    "@types/react-native": "~0.63.2",
-    "typescript": "~4.0.0"
+    "@babel/core": "^7.12.9",
+    "@types/react": "~17.0.21",
+    "@types/react-dom": "~17.0.9",
+    "@types/react-native": "~0.64.12",
+    "typescript": "~4.3.5"
   }
 }


### PR DESCRIPTION
With a warning though: 
```
EXGL: gl.pixelStorei() doesn't support this parameter yet!
```

If we don't support three anymore, maybe its better to remove this one.