### PR TITLE
[video-background] Upgrade to Expo SDK 43

### DIFF
--- a/with-video-background/package.json
+++ b/with-video-background/package.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-av": "~9.1.2",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-av": "~10.1.2",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Only Expo packages mean only fun packages (easy to update)