### PR TITLE
[webbrowser-redirect] Upgrade to Expo SDK 43

### DIFF
--- a/with-webbrowser-redirect/package.json
+++ b/with-webbrowser-redirect/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "expo": "~42.0.0",
-    "expo-linking": "~2.3.1",
-    "expo-web-browser": "~9.2.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
-    "react-native-web": "~0.13.12"
+    "expo": "^43.0.0",
+    "expo-linking": "~2.4.2",
+    "expo-web-browser": "~10.0.3",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.2",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0"
+    "@babel/core": "^7.12.9"
   }
 }


### PR DESCRIPTION
Shout out to the MVP who still hosts https://backend-xxswjknyfi.now.sh