### PR TITLE
Add basic preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,8 +17,8 @@ jobs:
           list-files: json
           filters: |
             examples:
-              - blank
-              - navigation
+              - blank/**
+              - navigation/**
               - with-**
       - id: find
         name: 📱 Find changed examples

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,8 +18,7 @@ jobs:
           filters: |
             examples:
               - blank/**
-              - navigation/**
-              - with-**
+              - with-!(dev-client|yarn-workspaces)/?**
       - id: find
         name: 📱 Find changed examples
         uses: actions/github-script@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,65 @@
+name: Expo Preview
+on:
+  push:
+    branches: [master, main]
+jobs:
+  changed:
+    name: Find changed apps
+    runs-on: ubuntu-latest
+    outputs:
+      exampleChanged: ${{ steps.filter.outputs.examples == 'true' }}
+      exampleNames: ${{ steps.find.outputs.result }}
+    steps:
+      - id: filter
+        name: 🕵️ Detect changes
+        uses: dorny/paths-filter@v2
+        with:
+          list-files: json
+          filters: |
+            examples:
+              - blank
+              - navigation
+              - with-**
+      - id: find
+        name: 📱 Find changed examples
+        uses: actions/github-script@v5
+        if: steps.filter.outputs.examples == 'true'
+        with:
+          script: |
+            // Load all changed files to dynamically fetch the app names
+            const path = require('path')
+            const changes = ${{ steps.filter.outputs.examples_files }}
+            // Iterate through all changes and keep unique app names
+            return [...new Set(changes.map(file => path.dirname(file).split('/', 1)[0]))]
+  publish:
+    needs: changed
+    if: needs.changed.outputs.exampleChanged
+    name: Publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: ${{ fromJSON(needs.changed.outputs.exampleNames) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.example }}
+    steps:
+      - name: 🏗️ Setup repo
+        uses: actions/checkout@v2
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: 🏗️ Setup Expo
+        uses: expo/expo-github-action@v6
+        with:
+          expo-version: 4.x
+          expo-cache: true
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: 📋 Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts --check-files
+      - name: ⚙️ Setup manifest
+        run: echo '{"expo":{"owner":"examples"}}' > app.json
+      - name: 🚀 Publish preview
+        run: expo publish
+
+          

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,5 +61,3 @@ jobs:
         run: echo '{"expo":{"owner":"examples"}}' > app.json
       - name: 🚀 Publish preview
         run: expo publish
-
-          


### PR DESCRIPTION
This is a basic version of the one I created at [bycedric/eas-monorepo-example](https://github.com/byCedric/eas-monorepo-example/pull/25). It has a couple of advantages over hardcoding paths:

- Check whatever example was changed
- Create parallel actions to publish

It's a start, I'll comment on some things we might want to consider