### PR TITLE
[with-typescript] Update react-native to 0.64.3 to match the updated Expo SDK@43

### DIFF
--- a/with-typescript/package.json
+++ b/with-typescript/package.json
@@ -3,7 +3,7 @@
     "expo": "^43.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-native": "0.64.2",
+    "react-native": "0.64.3",
     "react-native-web": "~0.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In the wake of this PR https://github.com/expo/examples/pull/339
I just want to update the react-native version to the current version (0.64.3) according to https://github.com/expo/expo/pull/15108