### PR TITLE
chore(with-react-three-fiber): update to v8, update docs

### DIFF
--- a/with-react-three-fiber/App.js
+++ b/with-react-three-fiber/App.js
@@ -1,36 +1,27 @@
 import React, { useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Canvas, useFrame } from 'react-three-fiber';
+import { Canvas, useFrame } from '@react-three/fiber/native';
 
 function Box(props) {
-  // This reference will give us direct access to the mesh
-  const mesh = useRef();
-
-  // Set up state for the hovered and active state
-  const [hovered, setHover] = useState(false);
-  const [active, setActive] = useState(false);
-
-  // Rotate mesh every frame, this is outside of React without overhead
-  useFrame(() => {
-    if (mesh && mesh.current) {
-      mesh.current.rotation.x = mesh.current.rotation.y += 0.01;
-    }
-  });
-
+  // This reference gives us direct access to the THREE.Mesh object
+  const ref = useRef();
+  // Hold state for hovered and clicked events
+  const [hovered, hover] = useState(false);
+  const [clicked, click] = useState(false);
+  // Subscribe this component to the render-loop, rotate the mesh every frame
+  useFrame((state, delta) => (ref.current.rotation.x += 0.01));
+  // Return the view, these are regular Threejs elements expressed in JSX
   return (
     <mesh
       {...props}
-      ref={mesh}
-      scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
-      onClick={(e) => setActive(!active)}
-      onPointerOver={(e) => setHover(true)}
-      onPointerOut={(e) => setHover(false)}
+      ref={ref}
+      scale={clicked ? 1.5 : 1}
+      onClick={event => click(!clicked)}
+      onPointerOver={event => hover(true)}
+      onPointerOut={event => hover(false)}
     >
-      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
-      <meshStandardMaterial
-        attach="material"
-        color={hovered ? "hotpink" : "orange"}
-      />
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>
   );
 }
@@ -39,8 +30,9 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Canvas>
-        <ambientLight />
-        <pointLight position={[10, 10, 10]} />
+        <ambientLight intensity={0.5} />
+        <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} />
+        <pointLight position={[-10, -10, -10]} />
         <Box position={[-1.2, 0, 0]} />
         <Box position={[1.2, 0, 0]} />
       </Canvas>
@@ -51,6 +43,5 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "black",
   },
 });

--- a/with-react-three-fiber/README.md
+++ b/with-react-three-fiber/README.md
@@ -20,6 +20,5 @@ Create Three.js projects using React components and props!
 
 ## 📝 Notes
 
-- [react-three-fiber docs](https://github.com/react-spring/react-three-fiber)
+- [react-three-fiber docs](https://docs.pmnd.rs/react-three-fiber)
 - [three.js docs](https://threejs.org/docs/)
-- [expo-three docs](https://github.com/expo/expo-three)

--- a/with-react-three-fiber/package.json
+++ b/with-react-three-fiber/package.json
@@ -1,14 +1,12 @@
 {
   "dependencies": {
     "expo": "^43.0.0",
-    "expo-gl": "~11.0.3",
-    "expo-three": "~5.7.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "18.0.0-beta-24dd07bd2-20211208",
+    "react-dom": "18.0.0-beta-24dd07bd2-20211208",
     "react-native": "0.64.3",
     "react-native-web": "0.17.1",
-    "react-three-fiber": "^5.3.19",
-    "three": "^0.122.0"
+    "react-three-fiber": "^8.0.0-beta-02",
+    "three": "^0.133.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/with-react-three-fiber/package.json
+++ b/with-react-three-fiber/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "expo": "^43.0.0",
-    "react": "18.0.0-beta-24dd07bd2-20211208",
-    "react-dom": "18.0.0-beta-24dd07bd2-20211208",
+    "react": "18.0.0-rc.0",
+    "react-dom": "18.0.0-rc.0",
     "react-native": "0.64.3",
     "react-native-web": "0.17.1",
-    "react-three-fiber": "^8.0.0-beta-02",
+    "react-three-fiber": "^8.0.0-beta-04",
     "three": "^0.133.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the react-three-fiber example to v8, using react 18 and react-dom 18 betas.