### PR TITLE
Add with-realm example

### DIFF
--- a/with-realm/App.tsx
+++ b/with-realm/App.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useMemo } from "react";
+import { SafeAreaView, View, StyleSheet } from "react-native";
+
+import TaskContext, { Task } from "./app/models/Task";
+import IntroText from "./app/components/IntroText";
+import AddTaskForm from "./app/components/AddTaskForm";
+import TaskList from "./app/components/TaskList";
+import colors from "./app/styles/colors";
+
+const { useRealm, useQuery, RealmProvider } = TaskContext;
+
+function App() {
+  const realm = useRealm();
+  const result = useQuery(Task);
+
+  const tasks = useMemo(() => result.sorted("createdAt"), [result]);
+
+  const handleAddTask = useCallback(
+    (description: string): void => {
+      if (!description) {
+        return;
+      }
+
+      // Everything in the function passed to "realm.write" is a transaction and will
+      // hence succeed or fail together. A transcation is the smallest unit of transfer
+      // in Realm so we want to be mindful of how much we put into one single transaction
+      // and split them up if appropriate (more commonly seen server side). Since clients
+      // may occasionally be online during short time spans we want to increase the probability
+      // of sync participants to successfully sync everything in the transaction, otherwise
+      // no changes propagate and the transaction needs to start over when connectivity allows.
+      realm.write(() => {
+        realm.create("Task", Task.generate(description));
+      });
+    },
+    [realm],
+  );
+
+  const handleToggleTaskStatus = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        // Normally when updating a record in a NoSQL or SQL database, we have to type
+        // a statement that will later be interpreted and used as instructions for how
+        // to update the record. But in RealmDB, the objects are "live" because they are
+        // actually referencing the object's location in memory on the device (memory mapping).
+        // So rather than typing a statement, we modify the object directly by changing
+        // the property values. If the changes adhere to the schema, Realm will accept
+        // this new version of the object and wherever this object is being referenced
+        // locally will also see the changes "live".
+        task.isComplete = !task.isComplete;
+      });
+
+      // Alternatively if passing the ID as the argument to handleToggleTaskStatus:
+      // realm?.write(() => {
+      //   const task = realm?.objectForPrimaryKey('Task', id); // If the ID is passed as an ObjectId
+      //   const task = realm?.objectForPrimaryKey('Task', Realm.BSON.ObjectId(id));  // If the ID is passed as a string
+      //   task.isComplete = !task.isComplete;
+      // });
+    },
+    [realm],
+  );
+
+  const handleDeleteTask = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        realm.delete(task);
+
+        // Alternatively if passing the ID as the argument to handleDeleteTask:
+        // realm?.delete(realm?.objectForPrimaryKey('Task', id));
+      });
+    },
+    [realm],
+  );
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.content}>
+        <AddTaskForm onSubmit={handleAddTask} />
+        {tasks.length === 0 ? (
+          <IntroText />
+        ) : (
+          <TaskList tasks={tasks} onToggleTaskStatus={handleToggleTaskStatus} onDeleteTask={handleDeleteTask} />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.darkBlue,
+  },
+  content: {
+    flex: 1,
+    paddingTop: 20,
+    paddingHorizontal: 20,
+  },
+});
+
+function AppWrapper() {
+  if (!RealmProvider) {
+    return null;
+  }
+  return (
+    <RealmProvider>
+      <App />
+    </RealmProvider>
+  );
+}
+
+export default AppWrapper;

--- a/with-realm/README.md
+++ b/with-realm/README.md
@@ -1,0 +1,49 @@
+# Expo Template Realm JavaScript
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+</p>
+
+Simple Expo template to quickly get started with Realm.
+
+## 🚀 How to use
+
+```
+npx expo-cli MyAwesomeRealmApp -t with-realm
+```
+
+## ☁️ Build in the cloud
+
+- [Building with EAS](https://docs.expo.dev/eas/)
+
+## 🏃 How to build and run locally
+
+- [Setup development Environment](https://reactnative.dev/docs/environment-setup)
+- Build/Run on iOS 🍎
+```
+yarn ios
+```
+```
+npm run ios
+```
+- Build/Run on Android 🤖
+```
+yarn android
+```
+```
+npm run android
+```
+
+## 🥸 Don't like TypeScript?
+
+Just replace the `App.tsx` and `app` folder with the source code of our [JavaScript template](https://github.com/realm/realm-js/tree/master/templates/expo-template-js)
+
+
+## 📝 Notes
+
+- [Setting up Sync](https://docs.mongodb.com/realm/sdk/react-native/quick-start/)
+- [Realm JS Documentation](https://docs.mongodb.com/realm/sdk/react-native/)
+- [Expo Development Client docs](https://docs.expo.dev/clients/introduction/)
+- [Building with EAS](https://docs.expo.dev/eas/)

--- a/with-realm/app/components/AddTaskForm.tsx
+++ b/with-realm/app/components/AddTaskForm.tsx
@@ -1,0 +1,87 @@
+import {useState} from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+
+import colors from '../styles/colors';
+
+interface AddTaskFormProps {
+  onSubmit: (description: string) => void;
+}
+
+function AddTaskForm({onSubmit}: AddTaskFormProps) {
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = () => {
+    onSubmit(description);
+    setDescription('');
+  };
+
+  return (
+    <View style={styles.form}>
+      <TextInput
+        value={description}
+        placeholder="Enter new task description"
+        onChangeText={setDescription}
+        autoCorrect={false}
+        autoCapitalize="none"
+        style={styles.textInput}
+      />
+      <Pressable onPress={handleSubmit} style={styles.submit}>
+        <Text style={styles.icon}>＋</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  form: {
+    height: 50,
+    marginBottom: 20,
+    flexDirection: 'row',
+    ...Platform.select({
+      ios: {
+        shadowColor: colors.black,
+        shadowOffset: {
+          width: 0,
+          height: 4,
+        },
+        shadowOpacity: 0.7,
+        shadowRadius: 3,
+      },
+      android: {
+        elevation: 3,
+      },
+    }),
+  },
+  textInput: {
+    flex: 1,
+    paddingHorizontal: 15,
+    paddingVertical: Platform.OS === 'ios' ? 15 : 0,
+    borderRadius: 5,
+    backgroundColor: colors.white,
+    fontSize: 17,
+  },
+  submit: {
+    height: '100%',
+    width: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 20,
+    borderRadius: 5,
+    backgroundColor: colors.purple,
+  },
+  icon: {
+    color: colors.white,
+    textAlign: 'center',
+    fontSize: 17,
+    fontWeight: 'bold',
+  },
+});
+
+export default AddTaskForm;

--- a/with-realm/app/components/IntroText.tsx
+++ b/with-realm/app/components/IntroText.tsx
@@ -1,0 +1,52 @@
+import {View, Text, Pressable, StyleSheet} from 'react-native';
+// @ts-ignore openURLInBrowser will open the url in your machine browser. (This isn't currently typed in React Native)
+import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
+
+import colors from '../styles/colors';
+
+function IntroText() {
+  return (
+    <View style={styles.content}>
+      <Text style={styles.paragraph}>
+        Welcome to the Realm React Native TypeScript Template
+      </Text>
+      <Text style={styles.paragraph}>
+        Start adding a task using the form at the top of the screen to see how
+        they are created in Realm. You can also toggle the task status or remove
+        it from the list.
+      </Text>
+      <Text style={styles.paragraph}>
+        Learn more about the React Native Realm SDK at:
+      </Text>
+      <Pressable
+        onPress={() =>
+          openURLInBrowser('https://docs.mongodb.com/realm/sdk/react-native/')
+        }>
+        <Text style={[styles.paragraph, styles.link]}>
+          docs.mongodb.com/realm/sdk/react-native
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    marginHorizontal: 20,
+    justifyContent: 'center',
+  },
+  paragraph: {
+    marginVertical: 10,
+    textAlign: 'center',
+    color: 'white',
+    fontSize: 17,
+    fontWeight: '500',
+  },
+  link: {
+    color: colors.purple,
+    fontWeight: 'bold',
+  },
+});
+
+export default IntroText;

--- a/with-realm/app/components/TaskItem.tsx
+++ b/with-realm/app/components/TaskItem.tsx
@@ -1,0 +1,105 @@
+import {memo} from 'react';
+import {View, Text, Pressable, Platform, StyleSheet} from 'react-native';
+
+import colors from '../styles/colors';
+
+interface TaskItemProps {
+  description: string;
+  isComplete: boolean;
+  onToggleStatus: () => void;
+  onDelete: () => void;
+}
+
+function TaskItem({
+  description,
+  isComplete,
+  onToggleStatus,
+  onDelete,
+}: TaskItemProps) {
+  return (
+    <View style={styles.task}>
+      <Pressable
+        onPress={onToggleStatus}
+        style={[styles.status, isComplete && styles.completed]}>
+        <Text style={styles.icon}>{isComplete ? '✓' : '○'}</Text>
+      </Pressable>
+      <View style={styles.descriptionContainer}>
+        <Text numberOfLines={1} style={styles.description}>
+          {description}
+        </Text>
+      </View>
+      <Pressable onPress={onDelete} style={styles.deleteButton}>
+        <Text style={styles.deleteText}>Delete</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  task: {
+    height: 50,
+    alignSelf: 'stretch',
+    flexDirection: 'row',
+    marginVertical: 8,
+    backgroundColor: colors.white,
+    borderRadius: 5,
+    ...Platform.select({
+      ios: {
+        shadowColor: colors.black,
+        shadowOffset: {
+          width: 0,
+          height: 4,
+        },
+        shadowOpacity: 0.7,
+        shadowRadius: 3,
+      },
+      android: {
+        elevation: 3,
+      },
+    }),
+  },
+  descriptionContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  description: {
+    paddingHorizontal: 10,
+    color: colors.black,
+    fontSize: 17,
+  },
+  status: {
+    width: 50,
+    height: '100%',
+    justifyContent: 'center',
+    borderTopLeftRadius: 5,
+    borderBottomLeftRadius: 5,
+    backgroundColor: colors.gray,
+  },
+  completed: {
+    backgroundColor: colors.purple,
+  },
+  deleteButton: {
+    justifyContent: 'center',
+  },
+  deleteText: {
+    marginHorizontal: 10,
+    color: colors.gray,
+    fontSize: 17,
+  },
+  icon: {
+    color: colors.white,
+    textAlign: 'center',
+    fontSize: 17,
+    fontWeight: 'bold',
+  },
+});
+
+// We want to make sure only tasks that change are rerendered
+const shouldNotRerender = (
+  prevProps: TaskItemProps,
+  nextProps: TaskItemProps,
+) =>
+  prevProps.description === nextProps.description &&
+  prevProps.isComplete === nextProps.isComplete;
+
+export default memo(TaskItem, shouldNotRerender);

--- a/with-realm/app/components/TaskList.tsx
+++ b/with-realm/app/components/TaskList.tsx
@@ -1,0 +1,40 @@
+import { View, FlatList, StyleSheet } from 'react-native';
+import { Realm } from '@realm/react';
+
+import { Task } from '../models/Task';
+import TaskItem from './TaskItem';
+
+interface TaskListProps {
+  tasks: Realm.Results<Task> | [];
+  onToggleTaskStatus: (task: Task) => void;
+  onDeleteTask: (task: Task) => void;
+}
+
+function TaskList({tasks, onToggleTaskStatus, onDeleteTask}: TaskListProps) {
+  return (
+    <View style={styles.listContainer}>
+      <FlatList
+        data={tasks}
+        keyExtractor={task => task._id.toString()}
+        renderItem={({item}) => (
+          <TaskItem
+            description={item.description}
+            isComplete={item.isComplete}
+            onToggleStatus={() => onToggleTaskStatus(item)}
+            onDelete={() => onDeleteTask(item)}
+            // Don't spread the Realm item as such: {...item}
+          />
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});
+
+export default TaskList;

--- a/with-realm/app/models/Task.ts
+++ b/with-realm/app/models/Task.ts
@@ -1,0 +1,32 @@
+import { Realm, createRealmContext } from "@realm/react";
+export class Task extends Realm.Object {
+  _id!: Realm.BSON.ObjectId;
+  description!: string;
+  isComplete!: boolean;
+
+  static generate(description: string) {
+    return {
+      _id: new Realm.BSON.ObjectId(),
+      description,
+      isComplete: false,
+      createdAt: new Date(),
+    };
+  }
+
+  // To use a class as a Realm object type, define the object schema on the static property "schema".
+  static schema = {
+    name: "Task",
+    primaryKey: "_id",
+    properties: {
+      _id: "objectId",
+      description: "string",
+      isComplete: { type: "bool", default: false },
+      createdAt: "date",
+    },
+  };
+}
+
+export default createRealmContext({
+  schema: [Task],
+  deleteRealmIfMigrationNeeded: true,
+});

--- a/with-realm/app/styles/colors.ts
+++ b/with-realm/app/styles/colors.ts
@@ -1,0 +1,9 @@
+const colors = {
+  darkBlue: '#2A3642',
+  purple: '#6E60F9',
+  gray: '#B5B5B5',
+  white: '#FFFFFF',
+  black: '#000000',
+};
+
+export default colors;

--- a/with-realm/babel.config.js
+++ b/with-realm/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/with-realm/eas.json
+++ b/with-realm/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 0.42.4"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/with-realm/index.js
+++ b/with-realm/index.js
@@ -1,0 +1,11 @@
+import 'expo-dev-client';
+import 'react-native-get-random-values';
+
+import { registerRootComponent } from "expo";
+
+import App from "./App";
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in the Expo client or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/with-realm/metro.config.js
+++ b/with-realm/metro.config.js
@@ -1,0 +1,4 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);

--- a/with-realm/package.json
+++ b/with-realm/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "expo start --dev-client",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "@realm/react": "^0.1.0",
+    "expo": "^44.0.3",
+    "expo-dev-client": "~0.8.0",
+    "react-native-get-random-values": "~1.7.2",
+    "realm": "^10.11.0"
+  }
+}


### PR DESCRIPTION
With the release of SDK 44 and the `expo-dev-client`, `realm` can
finally work with Expo!  

This example is based off of the templates
already existing in [RealmJS](https://github.com/realm/realm-js) and the `with-dev-client` Expo example