### PR TITLE
Fix up project init command

### DIFF
--- a/with-realm/README.md
+++ b/with-realm/README.md
@@ -1,4 +1,5 @@
 # Expo Template Realm JavaScript
+
 <p>
   <!-- iOS -->
   <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
@@ -11,7 +12,7 @@ Simple Expo template to quickly get started with Realm.
 ## 🚀 How to use
 
 ```
-npx expo-cli MyAwesomeRealmApp -t with-realm
+npx create-react-native-app MyAwesomeRealmApp -t with-realm
 ```
 
 ## ☁️ Build in the cloud
@@ -22,16 +23,21 @@ npx expo-cli MyAwesomeRealmApp -t with-realm
 
 - [Setup development Environment](https://reactnative.dev/docs/environment-setup)
 - Build/Run on iOS 🍎
+
 ```
 yarn ios
 ```
+
 ```
 npm run ios
 ```
+
 - Build/Run on Android 🤖
+
 ```
 yarn android
 ```
+
 ```
 npm run android
 ```
@@ -39,7 +45,6 @@ npm run android
 ## 🥸 Don't like TypeScript?
 
 Just replace the `App.tsx` and `app` folder with the source code of our [JavaScript template](https://github.com/realm/realm-js/tree/master/templates/expo-template-js)
-
 
 ## 📝 Notes
 


### PR DESCRIPTION
The command in the README.md was using `npx expo-cli` instead of `npx create-react-native-app`.
This has been updated avoid confusion.