### PR TITLE
Create react-native-webrtc Example

### DIFF
--- a/with-webrtc/App.js
+++ b/with-webrtc/App.js
@@ -1,12 +1,18 @@
-import { useState } from 'react';
-import { Button, SafeAreaView, StatusBar, StyleSheet, View } from 'react-native';
-import { mediaDevices, RTCView } from 'react-native-webrtc';
+import { useState } from "react";
+import {
+  Button,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  View,
+} from "react-native";
+import { mediaDevices, RTCView } from "react-native-webrtc";
 
 function App() {
   const [stream, setStream] = useState(null);
 
   const start = async () => {
-    console.log('start');
+    console.log("start");
     if (!stream) {
       let s;
       try {
@@ -19,7 +25,7 @@ function App() {
   };
 
   const stop = () => {
-    console.log('stop');
+    console.log("stop");
     if (stream) {
       stream.release();
       setStream(null);
@@ -27,30 +33,17 @@ function App() {
   };
 
   return (
-    <SafeAreaView style={StyleSheet.absoluteFillObject}>
+    <SafeAreaView style={{ flex: 1 }}>
       <StatusBar barStyle="dark-content" />
-      {
-        stream &&
-        <RTCView
-          streamURL={stream.toURL()}
-          style={{ flex: 1 }} />
-      }
-      <View
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0
-        }}>
-        <Button
-          title="Start"
-          onPress={start} />
-        <Button
-          title="Stop"
-          onPress={stop} />
+      <View style={{ flex: 1 }}>
+        {stream && <RTCView streamURL={stream.toURL()} style={{ flex: 1 }} />}
+      </View>
+      <View style={{ flexDirection: "row", justifyContent: "space-around" }}>
+        <Button title="Start" onPress={start} />
+        <Button title="Stop" onPress={stop} />
       </View>
     </SafeAreaView>
   );
-};
+}
 
 export default App;

--- a/with-webrtc/App.js
+++ b/with-webrtc/App.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Button, SafeAreaView, StatusBar, StyleSheet, View } from 'react-native';
+import { mediaDevices, RTCView } from 'react-native-webrtc';
+
+function App() {
+  const [stream, setStream] = useState(null);
+
+  const start = async () => {
+    console.log('start');
+    if (!stream) {
+      let s;
+      try {
+        s = await mediaDevices.getUserMedia({ video: true });
+        setStream(s);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  const stop = () => {
+    console.log('stop');
+    if (stream) {
+      stream.release();
+      setStream(null);
+    }
+  };
+
+  return (
+    <SafeAreaView style={StyleSheet.absoluteFillObject}>
+      <StatusBar barStyle="dark-content" />
+      {
+        stream &&
+        <RTCView
+          streamURL={stream.toURL()}
+          style={{ flex: 1 }} />
+      }
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0
+        }}>
+        <Button
+          title="Start"
+          onPress={start} />
+        <Button
+          title="Stop"
+          onPress={stop} />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default App;

--- a/with-webrtc/README.md
+++ b/with-webrtc/README.md
@@ -1,0 +1,38 @@
+# WebRTC Example
+
+![Supports iOS](https://img.shields.io/badge/iOS-000.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff)
+![Supports Android](https://img.shields.io/badge/Android-000.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff)
+
+Use `react-native-webrtc` in a custom [Expo Dev Client](https://docs.expo.dev/clients/introduction/) (not available in Expo Go).
+
+## 🚀 How to use
+
+```sh
+npx create-react-native-app -t with-webrtc
+```
+
+## ☁️ Build in the cloud
+
+- [Building with EAS](https://docs.expo.dev/eas/)
+
+## 🏃 How to build and run locally
+
+- [Setup development Environment](https://reactnative.dev/docs/environment-setup)
+- Build/Run on iOS 🍎
+
+```
+yarn ios
+```
+
+- Build/Run on Android 🤖
+
+```
+yarn android
+```
+
+## 📝 Notes
+
+- [React Native WebRTC](https://github.com/react-native-webrtc/)
+- [Expo Config Plugin: WebRTC](https://github.com/expo/config-plugins/tree/master/packages/react-native-webrtc)
+- [Expo Development Client docs](https://docs.expo.dev/clients/introduction/)
+- [Building with EAS](https://docs.expo.dev/eas/)

--- a/with-webrtc/README.md
+++ b/with-webrtc/README.md
@@ -18,17 +18,9 @@ npx create-react-native-app -t with-webrtc
 ## 🏃 How to build and run locally
 
 - [Setup development Environment](https://reactnative.dev/docs/environment-setup)
-- Build/Run on iOS 🍎
-
-```
-yarn ios
-```
-
-- Build/Run on Android 🤖
-
-```
-yarn android
-```
+- 🍎 Build/Run on iOS `yarn ios`.
+  - WebRTC doesn't work in the iOS Simulator since there is no camera. Run `expo run:ios -d` to select a connected iOS device.
+- 🤖 Build/Run on Android `yarn android`.
 
 ## 📝 Notes
 

--- a/with-webrtc/app.json
+++ b/with-webrtc/app.json
@@ -1,0 +1,7 @@
+{
+    "expo": {
+        "plugins": [
+            "@config-plugins/react-native-webrtc"
+        ]
+    }
+}

--- a/with-webrtc/app.json
+++ b/with-webrtc/app.json
@@ -1,7 +1,7 @@
 {
-    "expo": {
-        "plugins": [
-            "@config-plugins/react-native-webrtc"
-        ]
-    }
+  "expo": {
+    "plugins": [
+      "@config-plugins/react-native-webrtc"
+    ]
+  }
 }

--- a/with-webrtc/babel.config.js
+++ b/with-webrtc/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/with-webrtc/eas.json
+++ b/with-webrtc/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 0.42.4"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/with-webrtc/index.js
+++ b/with-webrtc/index.js
@@ -1,0 +1,10 @@
+import 'expo-dev-client';
+
+import { registerRootComponent } from "expo";
+
+import App from "./App";
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in the Expo client or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/with-webrtc/metro.config.js
+++ b/with-webrtc/metro.config.js
@@ -1,0 +1,4 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);

--- a/with-webrtc/package.json
+++ b/with-webrtc/package.json
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "start": "expo start --dev-client",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "react-native-webrtc": "^1.94.1",
+    "expo": "^44.0.3",
+    "expo-dev-client": "~0.8.0"
+  },
+  "devDependencies": {
+    "@config-plugins/react-native-webrtc": "^2.0.0"
+  }
+}

--- a/with-webrtc/package.json
+++ b/with-webrtc/package.json
@@ -7,9 +7,18 @@
   "dependencies": {
     "react-native-webrtc": "^1.94.1",
     "expo": "^44.0.3",
-    "expo-dev-client": "~0.8.0"
+    "expo-dev-client": "~0.8.0",
+    "expo-splash-screen": "~0.14.1",
+    "expo-status-bar": "~1.2.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-native": "0.64.3",
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@config-plugins/react-native-webrtc": "^2.0.0"
-  }
+    "@config-plugins/react-native-webrtc": "^2.0.1",
+    "@babel/core": "^7.12.9"
+  },
+  "name": "with-webrtc",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Created a Dev Client example for using `react-native-webrtc` with the out of tree plugin.

# Test Plan

- Dev: `expo run:ios -d` select connected iOS device.
- Prod: `expo run:ios -d --configuration Release` select connected iOS device.
- `expo run:android`