### PR TITLE
fix: firebase examples upstream breaking change

### DIFF
--- a/with-firebase-saml-login/metro.config.js
+++ b/with-firebase-saml-login/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+defaultConfig.resolver.sourceExts.push('cjs');
+
+module.exports = defaultConfig;

--- a/with-firebase-storage-upload/metro.config.js
+++ b/with-firebase-storage-upload/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+defaultConfig.resolver.sourceExts.push('cjs');
+
+module.exports = defaultConfig;

--- a/with-firebase-storage-upload/package.json
+++ b/with-firebase-storage-upload/package.json
@@ -3,7 +3,7 @@
     "expo": "^45.0.0",
     "expo-clipboard": "~3.0.1",
     "expo-image-picker": "~13.1.1",
-    "firebase": "^9.1.3",
+    "firebase": "^9.6.9",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.68.2",


### PR DESCRIPTION
**Why?**

https://github.com/expo/expo/issues/17469

**How?**

Added `cjs` to the source extensions.