### PR TITLE
Add exp:// as AuthSession callback URL for Twitter-Auth Example

### DIFF
--- a/with-twitter-auth/README.md
+++ b/with-twitter-auth/README.md
@@ -51,6 +51,6 @@ Expo Twitter Auth
 
 The AuthSession helps you with browser authentication, without the need of an additional server or website. To use this with Twitter authentication flows, we need to tell Twitter that the callback URLs are allowed.
 
-Each Expo user has it's own URL for different projects, the basic structure of this URL is `https://auth.expo.io/@your-username/your-expo-app-slug`. If you are signed in as `awesome-ppl`, and your app is called `meme-explorer`, your URL looks like `https://auth.expo.io/@awesome-ppl/meme-explorer`.
+Each Expo user has it's own URL for different projects, the basic structure of this URL is `https://auth.expo.io/@your-username/your-expo-app-slug`. If you are signed in as `awesome-ppl`, and your app is called `meme-explorer`, your URL looks like `https://auth.expo.io/@awesome-ppl/meme-explorer`. Additionally, you may need to also add `exp://` as a Callback URL in your project's General Authentication Settings in the Twitter Developer Portal.
 
 > [Read more about AuthSession here](https://docs.expo.dev/versions/latest/sdk/auth-session/)


### PR DESCRIPTION
Not sure if this is a new thing, but adding `exp://` as a callback URL was necessary for me to get the Twitter Auth Example working. Adding this PR to help alleviate stress to anyone new trying to get it working after me.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/22263679/171911347-24ec0fd5-d94b-4c2a-9ab0-dab91c45bde5.png">
