### PR TITLE
[with-nextjs] bump Next, update configs

### DIFF
--- a/with-nextjs/babel.config.js
+++ b/with-nextjs/babel.config.js
@@ -1,4 +1,0 @@
-// @generated: @expo/next-adapter@2.1.52
-// Learn more: https://docs.expo.dev/guides/using-nextjs/
-
-module.exports = { presets: ['@expo/next-adapter/babel'] };

--- a/with-nextjs/next.config.js
+++ b/with-nextjs/next.config.js
@@ -1,8 +1,11 @@
-// @generated: @expo/next-adapter@2.1.52
 // Learn more: https://docs.expo.io/guides/using-nextjs/
 
 const { withExpo } = require('@expo/next-adapter');
+const withTM = require('next-transpile-modules')(['react-native-web']);
 
-module.exports = withExpo({
-  projectRoot: __dirname,
-});
+module.exports = () => {
+  const plugins = [withTM, withExpo];
+  return plugins.reduce((acc, next) => next(acc), {
+    // Next Config
+  });
+};

--- a/with-nextjs/package.json
+++ b/with-nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "expo": "^46.0.0",
-    "next": "9.3.5",
+    "next": "^12.2.5",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-native": "0.69.4",
@@ -9,7 +9,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
-    "@expo/next-adapter": "~2.1.52"
+    "@expo/next-adapter": "^4.0.12",
+    "next-transpile-modules": "^9.0.0"
   },
   "scripts": {
     "start": "next dev",

--- a/with-nextjs/pages/_document.js
+++ b/with-nextjs/pages/_document.js
@@ -1,2 +1,1 @@
-// @generated: @expo/next-adapter@2.1.52
 export { default } from '@expo/next-adapter/document';

--- a/with-nextjs/pages/index.js
+++ b/with-nextjs/pages/index.js
@@ -1,4 +1,3 @@
-// @generated: @expo/next-adapter@2.1.52
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 


### PR DESCRIPTION
Supersede #350

Refs [ENG-6087](https://linear.app/expo/issue/ENG-6087)

# Why

Current Next example become outdated a bit, let's update it.

# How

This PR bumps Next to the latest release, updates config and removes Babel config which seems to be no longer required.