### PR TITLE
add with-nativewind example

### DIFF
--- a/with-nativewind/App.js
+++ b/with-nativewind/App.js
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function App() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Universal React with Expo</Text>
+    </View>
+  );
+}

--- a/with-nativewind/README.md
+++ b/with-nativewind/README.md
@@ -1,0 +1,23 @@
+# NativeWind Example
+
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+  <!-- Web -->
+  <img alt="Supports Expo Web" longdesc="Supports Expo Web" src="https://img.shields.io/badge/web-4630EB.svg?style=flat-square&logo=GOOGLE-CHROME&labelColor=4285F4&logoColor=fff" />
+</p>
+
+## 🚀 How to use
+
+<!-- Setup instructions -->
+
+- Install with `yarn` or `npm install`.
+- Run `yarn start` or `npm run start` to try it out.
+
+## 📝 Notes
+
+<!-- Link to related Expo or library docs -->
+
+- This example is using the [`nativewind`](https://www.nativewind.dev/) library which lets you use Tailwind CSS in react-native.

--- a/with-nativewind/app.json
+++ b/with-nativewind/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "blank",
+    "slug": "blank",
+    "version": "1.0.0",
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ]
+  }
+}

--- a/with-nativewind/babel.config.js
+++ b/with-nativewind/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/with-nativewind/package.json
+++ b/with-nativewind/package.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "expo": "^46.0.0",
+    "nativewind": "^2.0.10",
+    "react": "18.0.0",
+    "react-dom": "18.0.0",
+    "react-native": "0.69.4",
+    "react-native-web": "~0.18.7"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.18.6",
+    "tailwindcss": "^3.1.8"
+  }
+}

--- a/with-nativewind/tailwind.config.js
+++ b/with-nativewind/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./App.{js,jsx,ts,tsx}', './screens/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
I have added [NativeWind](https://www.nativewind.dev/) example in this pull request. NativeWind allows us to use Tailwind CSS in react-native. I know that there is already one example with tailwind-rn but I felt that NativeWind feels more similar to using Tailwind CSS on the web, and provides better intellisense.