### PR TITLE
[with-sqlite] add scripts to run example

### DIFF
--- a/with-sqlite/package.json
+++ b/with-sqlite/package.json
@@ -1,4 +1,10 @@
 {
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
   "dependencies": {
     "expo": "^46.0.0",
     "expo-sqlite": "~10.3.0",


### PR DESCRIPTION
The README tells you to run the project via `yarn start` but there is no script specified to do so in `package.json`.