### PR TITLE
fix(with-router): bump Metro to include windows posix fix

### DIFF
--- a/with-router/package.json
+++ b/with-router/package.json
@@ -20,12 +20,12 @@
     "@babel/core": "^7.18.6"
   },
   "resolutions": {
-    "metro": "^0.72.3",
-    "metro-resolver": "^0.72.3"
+    "metro": "^0.73.1",
+    "metro-resolver": "^0.73.1"
   },
   "overrides": {
-    "metro": "^0.72.3",
-    "metro-resolver": "^0.72.3"
+    "metro": "^0.73.1",
+    "metro-resolver": "^0.73.1"
   },
   "name": "with-router",
   "version": "1.0.0"


### PR DESCRIPTION
See: https://github.com/expo/router/issues/13