### PR TITLE
fix(router): define `main` entrypoint in `package.json`

### DIFF
--- a/with-router/package.json
+++ b/with-router/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "with-router",
+  "version": "1.0.0",
+  "main": "index.js",
   "scripts": {
     "start": "expo start"
   },
@@ -29,7 +32,5 @@
   "overrides": {
     "metro": "^0.73.7",
     "metro-resolver": "^0.73.7"
-  },
-  "name": "with-router",
-  "version": "1.0.0"
+  }
 }


### PR DESCRIPTION
See: https://expo.github.io/router/docs/#getting-started