### PR TITLE
fix(router): bump react native to `0.71.4`

### DIFF
--- a/with-router/package.json
+++ b/with-router/package.json
@@ -11,7 +11,7 @@
     "expo-status-bar": "~1.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.71.3",
+    "react-native": "0.71.4",
     "react-native-gesture-handler": "~2.9.0",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",


### PR DESCRIPTION
When starting the example, you instantly get the warning:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/1203991/229295689-46c805fc-4c85-4191-82cb-bbd2aa0d3d58.png">

Probably have to do this for other examples too.