### PR TITLE
Add start script to package.json

### DIFF
--- a/with-facebook-auth/package.json
+++ b/with-facebook-auth/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"
+  },
+  "scripts": {
+    "start": "expo start"
   }
 }


### PR DESCRIPTION
This commit adds the missing **'start script'** to the `package.json`  file of the **'with-facebook-auth'** example. This script is necessary for running the example correctly.

**Note:** The documentation currently states to run the program using 'yarn' and 'yarn start'. However, running these commands alone results in the error 'Command "start" not found'.

To address this issue, I added the missing startup script to the package.json file. After adding the following script:
```
"scripts": {
  "start": "expo start"
}
```

The program can now be executed successfully using: **`'yarn start'`** or **`'expo start'`** or **`'npm run start'`**. This ensures the proper startup of the application.
