### PR TITLE
set root for default endpoint to prevent TypeError

### DIFF
--- a/with-socket-io/backend/index.js
+++ b/with-socket-io/backend/index.js
@@ -16,7 +16,7 @@ setInterval(() => {
 }, 1000);
 
 // Show the index.html by default
-app.get('/', (req, res) => res.sendFile('index.html'));
+app.get('/', (req, res) => res.sendFile('index.html', { root: '.' }));
 
 // Start the express server
 http.listen(3000, function(){


### PR DESCRIPTION
Added root to default endpoint to prevent the following error:
TypeError: path must be absolute or specify root to res.sendFile1