### PR TITLE
Disable outdated preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Expo Preview
 on:
   push:
-    branches: [master, main]
+    branches: []
 jobs:
   changed:
     name: Find changed apps


### PR DESCRIPTION
The GitHub "preview" workflow relies on the outdated global Expo CLI, specifically `expo publish`, which no longer works in SDK 49 and later (it is part of classic updates). Disabling the workflow until a decision is made to fix or remove it.