### PR TITLE
[with-gatsby] Remove docs link

### DIFF
--- a/with-gatsby/README.md
+++ b/with-gatsby/README.md
@@ -1,8 +1,6 @@
 # [Gatsby Example](https://www.gatsbyjs.org/)
 
-> 💡 The most updated info is in the Expo docs: [Using Gatsby](https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-gatsby.md)
-
-Using Gatsby with Expo will enable you to [prerender](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. This demo shows you how to setup your universal application to use use advanced universal modules from the Expo SDK like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
+Using Gatsby with Expo will enable you to [prerender](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. This demo shows you how to setup your universal application to use advanced universal modules from the Expo SDK like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
 
 > Notice: Prerendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby. If you find bugs please report them on the [Expo repo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
 


### PR DESCRIPTION
We do not have Using Gatsby guide anymore. This PR removes the removed link from the `with-gatsby/README.md` example.