### PR TITLE
chore(with-nextjs): update to `next@14` with `@expo/next-adapter@6`

### DIFF
--- a/with-nextjs/package.json
+++ b/with-nextjs/package.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
     "expo": "^49.0.3",
-    "next": "~13.1.1",
-    "react": "18.1.0",
-    "react-dom": "18.1.0",
-    "react-native": "0.70.5",
-    "react-native-web": "~0.18.7"
+    "next": "~14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.6",
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
-    "@expo/next-adapter": "~5.0.0"
+    "@expo/next-adapter": "^6.0.0"
   },
   "scripts": {
     "start": "next dev",


### PR DESCRIPTION
This bumps the `with-nextjs` example to Next 14 and the adapter v6 (which contains peer dependency version loosening)

See: https://github.com/expo/expo-webpack-integrations/pull/25