### PR TITLE
chore: add workflow to keep dependencies up-to-date

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,68 @@
+name: Expo Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        description: Are we upgrading to `expo@latest`, or just fixing dependencies?
+        required: true
+        default: fix-dependencies
+        options:
+          - upgrade-expo
+          - fix-dependencies
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: 🏗️ Setup repo
+        uses: actions/checkout@v4
+
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+
+      - name: 📦 Upgrade Expo SDK
+        if: ${{ inputs.mode == 'upgrade-expo' }}
+        run: bash ./upgrade-dependencies.sh --upgrade-expo
+
+      - name: 💬 Create new upgrade PR
+        if: ${{ inputs.mode == 'upgrade-expo' }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: automated-upgrade
+          reviewers: |
+            byCedric
+            keith-kurak
+          title: Upgraded Expo SDK to `expo@latest`
+          body: |
+            This PR was automatically created by the [upgrade workflow](./.github/workflows/upgrade.yml).
+            Please review the changes and merge it when you're ready.
+
+      - name: 👷 Fix Expo dependencies
+        if: ${{ inputs.mode == 'fix-dependencies' }}
+        run: bash ./upgrade-dependencies.sh --fix-dependencies
+
+      - name: 💬 Create new fix PR
+        if: ${{ inputs.mode == 'fix-dependencies' }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: automated-fix
+          reviewers: |
+            byCedric
+            keith-kurak
+          title: Fixed all Expo SDK dependencies
+          body: |
+            This PR was automatically created by the [upgrade workflow](./.github/workflows/upgrade.yml).
+            Please review the changes and merge it when you're ready.
+
+      - name: 📋 Uploading logs
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            .sdk-upgrade-logs
+            .sdk-fix-logs

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -38,6 +38,7 @@ jobs:
           reviewers: |
             byCedric
             keith-kurak
+          commit-message: 'chore: upgrade expo to `latest`'
           title: Upgraded Expo SDK to `expo@latest`
           body: |
             This PR was automatically created by the [upgrade workflow](./.github/workflows/upgrade.yml).
@@ -55,6 +56,7 @@ jobs:
           reviewers: |
             byCedric
             keith-kurak
+          commit-message: 'chore: fix expo dependencies'
           title: Fixed all Expo SDK dependencies
           body: |
             This PR was automatically created by the [upgrade workflow](./.github/workflows/upgrade.yml).

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ report.html
 
 # Maintenance logs
 .sdk-upgrade-logs
+.sdk-fix-logs

--- a/upgrade-dependencies.sh
+++ b/upgrade-dependencies.sh
@@ -3,12 +3,12 @@
 if [ "$1" == "" ] || [ "$1" == "--help" ]; then
   echo "Available flags:"
   echo "--help"
-  echo "--run-expo-upgrade - run yarn to add latest Expo and npx expo install --fix upgrade to update to latest SDK on all examples"
-  echo "--run-fix-dependencies - run npx expo install --fix on all repos"
+  echo "--upgrade-expo - run yarn to add latest Expo and npx expo install --fix upgrade to update to latest SDK on all examples"
+  echo "--fix-dependencies - run npx expo install --fix on all repos"
   exit 0
 fi
 
-if [ "$1" == "--run-expo-upgrade" ]; then
+if [ "$1" == "--upgrade-expo" ]; then
   echo "Upgrading all projects to the latest SDK..."
   echo "For each example, this will run `yarn` to add latest Expo and then run `npx expo install --fix`, accepting all defaults."
   echo "Upgrade logs will be written to .sdk-upgrade-logs."
@@ -18,16 +18,16 @@ if [ "$1" == "--run-expo-upgrade" ]; then
     DIRNAME=${d%/}
     echo "Upgrading $DIRNAME..."
     echo "• Run yarn"
-    (cd $DIRNAME && yarn --silent) # If yarn fails spectacularly, we'll see evidence in the logs for expo upgrade
+    (cd $DIRNAME && yarn install --silent) # If yarn fails spectacularly, we'll see evidence in the logs for expo upgrade
     echo "• Run expo upgrade"
-    (cd $DIRNAME && yarn add expo@latest && npx expo install --fix > ../.sdk-upgrade-logs/$DIRNAME.txt)
+    (cd $DIRNAME && yarn add expo@latest && npx expo install --fix &> ../.sdk-upgrade-logs/$DIRNAME.txt)
   done
 
   # yarn workspaces has example(s) inside of app folder
   echo "• Run expo upgrade on apps inside with-yarn-workspaces"
   mkdir ./.sdk-upgrade-logs/with-yarn-workspaces
   for d in  with-yarn-workspaces/apps/*/ ; do
-    (cd $DIRNAME && yarn add expo@latest && npx expo install --fix > ../.sdk-upgrade-logs/with-yarn-workspaces/$DIRNAME.txt)
+    (cd $DIRNAME && yarn add expo@latest && npx expo install --fix &> ../.sdk-upgrade-logs/with-yarn-workspaces/$DIRNAME.txt)
   done
 
   echo "Upgrades complete! Check .sdk-upgrade-logs for results. Be sure to correct any errors or warnings."
@@ -37,20 +37,27 @@ if [ "$1" == "--run-expo-upgrade" ]; then
   exit 0
 fi
 
-if [ "$1" == "--run-fix-dependencies" ]; then
+if [ "$1" == "--fix-dependencies" ]; then
   echo "Fixing dependencies on all examples..."
 
   mkdir ./.sdk-upgrade-logs
   for d in */ ; do
     DIRNAME=${d%/}
     echo "Fixing dependencies on $DIRNAME..."
-    (cd $DIRNAME && npx expo install --fix)
+    echo "• Run yarn"
+    (cd $DIRNAME && yarn install --silent) # If yarn fails spectacularly, we'll see evidence in the logs for expo upgrade
+    echo "• Run fix"
+    (cd $DIRNAME && npx expo install --fix &> ../.sdk-fix-logs/$DIRNAME.txt)
   done
 
   echo "Fixing dependencies on apps inside with-yarn-workspaces..."
   mkdir ./.sdk-upgrade-logs/with-yarn-workspaces
   for d in  with-yarn-workspaces/apps/*/ ; do
-    (cd $DIRNAME && npx expo install --fix)
+    echo "• Fixing dependencies on apps inside with-yarn-workspaces"
+    echo "• Run yarn"
+    (cd $DIRNAME && yarn install --silent) # If yarn fails spectacularly, we'll see evidence in the logs for expo upgrade
+    echo "• Run fix"
+    (cd $DIRNAME && npx expo install --fix &> ../.sdk-fix-logs/with-yarn-workspaces/$DIRNAME.txt)
   done
 
   echo "Dependency fixes complete!"


### PR DESCRIPTION
If this works well, we can also schedule the `--fix-dependencies` through a corn job.