### PR TITLE
Updated the Template code to fix Buffer Deprecation Warning [with-react-three-fiber]

### DIFF
--- a/with-react-three-fiber/App.js
+++ b/with-react-three-fiber/App.js
@@ -1,16 +1,14 @@
 import { useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { Canvas, useFrame } from "@react-three/fiber";
+import { useFrame, Canvas } from "@react-three/fiber";
+// To fix WARN: THREE.BoxBufferGeometry has been renamed to THREE.BoxGeometry.
+import { Box } from "@react-three/drei";
 
-function Box(props) {
-  // This reference will give us direct access to the mesh
+function InteractiveBox(props) {
   const mesh = useRef();
-
-  // Set up state for the hovered and active state
   const [hovered, setHover] = useState(false);
   const [active, setActive] = useState(false);
 
-  // Rotate mesh every frame, this is outside of React without overhead
   useFrame(() => {
     if (mesh && mesh.current) {
       mesh.current.rotation.x = mesh.current.rotation.y += 0.01;
@@ -18,7 +16,7 @@ function Box(props) {
   });
 
   return (
-    <mesh
+    <Box
       {...props}
       ref={mesh}
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
@@ -26,12 +24,8 @@ function Box(props) {
       onPointerOver={(e) => setHover(true)}
       onPointerOut={(e) => setHover(false)}
     >
-      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
-      <meshStandardMaterial
-        attach="material"
-        color={hovered ? "hotpink" : "orange"}
-      />
-    </mesh>
+      <meshStandardMaterial color={hovered ? "hotpink" : "orange"} />
+    </Box>
   );
 }
 
@@ -41,8 +35,8 @@ export default function App() {
       <Canvas>
         <ambientLight />
         <pointLight position={[10, 10, 10]} />
-        <Box position={[-1.2, 0, 0]} />
-        <Box position={[1.2, 0, 0]} />
+        <InteractiveBox position={[-1.2, 0, 0]} />
+        <InteractiveBox position={[1.2, 0, 0]} />
       </Canvas>
     </View>
   );

--- a/with-react-three-fiber/metro.config.js
+++ b/with-react-three-fiber/metro.config.js
@@ -1,0 +1,24 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = (async () => {
+    /** @type {import('expo/metro-config').MetroConfig} */
+    const config = getDefaultConfig(__dirname, {
+        // Enable CSS support.
+        isCSSEnabled: true,
+    });
+
+    // Override the resolver configuration with your specified values.
+    config.resolver = {
+        sourceExts: ['js', 'json', 'ts', 'tsx', 'cjs', 'mjs'],
+        assetExts: ['glb', 'gltf', 'png', 'jpg', 'hdr'],
+    };
+
+    config.transformer.getTransformOptions =  async () => ({
+        transform: {
+            experimentalImportSupport: false,
+            inlineRequires: false,
+        },
+    });
+
+    return config;
+});


### PR DESCRIPTION
With the original template you would get this error 

`WARN  THREE.BoxBufferGeometry has been renamed to THREE.BoxGeometry.`

as in [RF125 ](https://discourse.threejs.org/t/three-geometry-will-be-removed-from-core-with-r125/22401)

So using 

`import { Box } from "@react-three/drei";` 

with proper 

`metro.config.js`

cleans up our terminal errors and away from deprecated features.