### PR TITLE
[with-storybook] Fix error after upgrading to Expo SDK 50

### DIFF
--- a/with-storybook/.storybook/main.js
+++ b/with-storybook/.storybook/main.js
@@ -18,7 +18,6 @@ const config = {
       options: {
         modulesToTranspile: [],
         projectRoot: "../",
-        babelPlugins: ["@babel/plugin-proposal-export-namespace-from"],
       },
     },
   ],


### PR DESCRIPTION
This PR fixes the following error:
```
Error: Cannot find package '@babel/plugin-proposal-export-namespace-from' imported from ~/expo/examples/with-storybook/babel-virtual-resolve-base.js
```

It is safe to remove this babelPlugin, as it is not used by any of the packages in the example, see also: [docs](https://github.com/storybookjs/addon-react-native-web/?tab=readme-ov-file#adding-babel-plugins).

## Reproduce error
- clone the Expo Examples repository: `git clone git@github.com:expo/examples.git`
- `cd with-storybook`
- `npm install`
- `npm run storybook`
- You will see the error

Similarly the fix can be reproduced by navigating to the fix branch.