### PR TITLE
chore: upgrade with-typescript example to expo^50.0.7

### DIFF
--- a/with-typescript/package.json
+++ b/with-typescript/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "expo": "^50.0.1",
+    "expo": "^50.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.73.2",
+    "react-native": "0.73.4",
     "react-native-web": "~0.19.6"
   },
   "devDependencies": {


### PR DESCRIPTION
- Upgrade with typescript example to expo version 50.0.7