### PR TITLE
fix: change not valid icon name from ios-code to code

### DIFF
--- a/navigation/navigation/BottomTabNavigator.js
+++ b/navigation/navigation/BottomTabNavigator.js
@@ -25,7 +25,7 @@ export default function BottomTabNavigator() {
         options={{
           headerShown: false,
           tabBarIcon: ({ color }) => (
-            <TabBarIcon name="ios-code" color={color} />
+            <TabBarIcon name="code" color={color} />
           ),
         }}
       />
@@ -35,7 +35,7 @@ export default function BottomTabNavigator() {
         options={{
           headerShown: false,
           tabBarIcon: ({ color }) => (
-            <TabBarIcon name="ios-code" color={color} />
+            <TabBarIcon name="code" color={color} />
           ),
         }}
       />


### PR DESCRIPTION
After compiling there isa warning 
![image](https://github.com/expo/examples/assets/76836550/5fef5469-7b3b-43bd-93e4-3b55bc8140e8)
