### PR TITLE
docs: switch to `create-expo` to unify example creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   <a aria-label="Follow @expo on Twitter" href="https://twitter.com/intent/follow?screen_name=expo" target="_blank">
     <img  alt="Twitter: expo" src="https://img.shields.io/twitter/follow/expo.svg?style=flat-square&label=Follow%20%40expo&logo=TWITTER&logoColor=FFFFFF&labelColor=00aced&logoWidth=15&color=lightgray" />
   </a>
-  
+
   <a aria-label="Star expo examples on Github" href="https://github.com/expo/examples">
     <img aria-label="Star the repo" align="right" alt="Star expo-examples on Github" src="https://img.shields.io/github/stars/expo/examples.svg?style=flat-square&label=Star%20on%20Github&logo=GITHUB&logoColor=FFFFFF&labelColor=24292e&logoWidth=15&color=lightgray" />
   </a>
@@ -41,26 +41,18 @@
 
 ## Usage
 
-Use this repo to create new React/React Native projects with [**create-expo-app**](https://github.com/expo/expo/tree/main/packages/create-expo#readme) or [**create-react-native-app**](https://github.com/expo/create-react-native-app).
+Use this repo to create new React/React Native projects with [**create-expo**](https://github.com/expo/expo/tree/main/packages/create-expo#readme) or [**create-react-native-app**](https://github.com/expo/create-react-native-app).
 
 ```sh
 npm create expo ./<path> --example <Example>
+npx create-expo ./<path> --example <Example>
 npx create-react-native-app --template <Example>
 
 # Example - typescript
 
 npm create expo ./typescript-app --example with-typescript
+npx create-expo ./typescript-app --example with-typescript
 npx create-react-native-app -t with-typescript
-```
-
-Or new Expo projects using [**create-expo-app**](https://www.npmjs.com/package/create-expo-app):
-
-```sh
-npx create-expo-app --example <Example>
-
-# Example - typescript
-
-npx create-expo-app -e with-typescript
 ```
 
 ## Contributors ✨

--- a/contributing.md
+++ b/contributing.md
@@ -8,7 +8,7 @@ Thanks for contributing! 😁 Here are some rules that will make your example la
   - Start with the [blank example](./blank).
   - We use a unified [`.gitignore`](./.gitignore)
   - No `package.json` or `app.config.js` values that aren't completely necessary
-    - Avoid `scripts` as these get added by `create-react-native-app`.
+    - Avoid `scripts` as these get added by `create-expo`.
   - Use the new `app.config.js` instead of `app.json`
   - Do not include an `app.config.js` unless it has values that are relevant to the example
   - Use remote files for the default assets in the `app.config.js`:
@@ -19,10 +19,10 @@ Thanks for contributing! 😁 Here are some rules that will make your example la
   - Limit package versions to patches only in the `package.json`:
   ```diff
   + "expo-three": "~1.0.0"
-  
+
   - "expo-three": "^1.0.0"
   ```
-- Each example can be used as a template in `create-react-native-app` so try to consider what a fresh template should look like:
+- Each example can be used as example in `create-expo` so try to consider what a fresh template should look like:
   - No **TODO**, **NOTE()**, or otherwise.
   - No personal references to your name or other contextual info in comments.
 

--- a/with-dev-client/README.md
+++ b/with-dev-client/README.md
@@ -11,7 +11,7 @@ Experiment with Development Client in SDK 40.
 
 ## 🚀 How to use
 
-> `npx create-react-native-app my-app -t with-dev-client`
+> `npx create-expo my-app --example with-dev-client`
 
 - Run `expo start --dev-client` to try it out.
 

--- a/with-moti/README.md
+++ b/with-moti/README.md
@@ -17,7 +17,7 @@
 
 ## 🚀 How to use
 
-> `npx create-react-native-app -t with-moti`
+> `npx create-expo --example with-moti`
 
 - Install packages with `yarn` or `npm install`.
   - If you have native iOS code run `npx pod-install`

--- a/with-native-base/README.md
+++ b/with-native-base/README.md
@@ -9,7 +9,7 @@
 - Create a new project with the following command:
 
 ```sh
-npx create-react-native-app -t with-native-base
+npx create-expo --example with-native-base
 ```
 
 - Run `yarn start` or `npm run start` to try it out.

--- a/with-pdf/README.md
+++ b/with-pdf/README.md
@@ -8,7 +8,7 @@ Use `react-native-pdf` in a custom [Expo Dev Client](https://docs.expo.dev/clien
 ## 🚀 How to use
 
 ```sh
-npx create-react-native-app -t with-pdf
+npx create-expo --example with-pdf
 ```
 
 ## ☁️ Build in the cloud

--- a/with-react-three-fiber/README.md
+++ b/with-react-three-fiber/README.md
@@ -13,7 +13,7 @@ Create Three.js projects using React components and props!
 
 ## 🚀 How to use
 
-> `npx create-react-native-app my-app -t with-react-three-fiber`
+> `npx create-expo my-app --example with-react-three-fiber`
 
 - Run `yarn` or `npm install`
 - Run `yarn start` or `npm run start` to try it out.

--- a/with-realm/README.md
+++ b/with-realm/README.md
@@ -12,7 +12,7 @@ Simple Expo template to quickly get started with Realm.
 ## 🚀 How to use
 
 ```
-npx create-react-native-app MyAwesomeRealmApp -t with-realm
+npx create-expo MyAwesomeRealmApp --example with-realm
 ```
 
 ## ☁️ Build in the cloud

--- a/with-reanimated/README.md
+++ b/with-reanimated/README.md
@@ -10,7 +10,7 @@
 
 ## 🚀 How to use
 
-> `npx create-react-native-app my-app -t with-reanimated`
+> `npx create-expo my-app --example with-reanimated`
 
 - Run `yarn` or `npm install`
 - Run `yarn start` or `npm run start` to try it out.

--- a/with-tfjs-camera/README.md
+++ b/with-tfjs-camera/README.md
@@ -11,7 +11,7 @@ Identify objects in real time using `@tensorflow/tfjs`, `expo-camera`, and `expo
 
 ## 🚀 How to use
 
-> `npx create-react-native-app my-app -t with-tfjs-camera`
+> `npx create-expo my-app --example with-tfjs-camera`
 
 - Run `yarn start` or `npm run start`, open on a native device (simulator, emulator, and browser are not supported).
 - You can swap out `@tensorflow-models/mobilenet` for another [TensorFlow model](https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md) to achieve different results.

--- a/with-typescript/README.md
+++ b/with-typescript/README.md
@@ -10,7 +10,7 @@
 </p>
 
 ```sh
-npx create-react-native-app -t with-typescript
+npx create-expo --example with-typescript
 ```
 
 TypeScript is a superset of JavaScript which gives you static types and powerful tooling in Visual Studio Code including autocompletion and useful inline warnings for type errors.
@@ -20,7 +20,7 @@ TypeScript is a superset of JavaScript which gives you static types and powerful
 #### Creating a new project
 
 - Install the CLI: `npm i -g expo-cli`
-- Create a project: `npx create-react-native-app -t with-typescript`
+- Create a project: `npx create-expo --example with-typescript`
 - `cd` into the project
 
 ### Adding TypeScript to existing projects

--- a/with-webrtc/README.md
+++ b/with-webrtc/README.md
@@ -8,7 +8,7 @@ Use `react-native-webrtc` in a custom [Expo Dev Client](https://docs.expo.dev/cl
 ## 🚀 How to use
 
 ```sh
-npx create-react-native-app -t with-webrtc
+npx create-expo --example with-webrtc
 ```
 
 ## ☁️ Build in the cloud

--- a/with-workbox/README.md
+++ b/with-workbox/README.md
@@ -10,7 +10,7 @@
 </p>
 
 ```sh
-npx create-react-native-app -t with-workbox
+npx create-expo --example with-workbox
 ```
 
 [Workbox](https://developers.google.com/web/tools/workbox) is a collection of libraries for creating and managing powerful web service workers. Service workers can be used to add offline support to websites.
@@ -22,7 +22,7 @@ This example is based on the [create-react-app](https://create-react-app.dev/doc
 #### Creating a new project
 
 - Install the CLI: `npm i -g expo-cli`
-- Create a project: `npx create-react-native-app -t with-workbox`
+- Create a project: `npx create-expo --example with-workbox`
 - `cd` into the project
 
 ### Testing the service worker

--- a/with-yarn-workspaces/README.md
+++ b/with-yarn-workspaces/README.md
@@ -20,7 +20,7 @@ This example installs a monorepo with an application using a separate custom pac
 
 ## 🚀 How to use
 
-- Create a new monorepo with `npx create-react-native-app --template with-yarn-workspaces`.
+- Create a new monorepo with `npx create-expo --example with-yarn-workspaces`.
 - Run `yarn watch-packages` to build and watch the packages.
 - Run `yarn start-app` to start the app.
 - Edit the code in **packages/expo-custom/src** and watch it live-reload in the app!


### PR DESCRIPTION
This moves all `create-react-native-app` references to `create-expo`.