### PR TITLE
fix: typo on with-router-tailwind

### DIFF
--- a/with-router-tailwind/src/app/index.tsx
+++ b/with-router-tailwind/src/app/index.tsx
@@ -26,7 +26,7 @@ function Content() {
               Welcome to Project ACME
             </Text>
             <Text className="mx-auto max-w-[700px] text-lg text-center text-gray-500 md:text-xl dark:text-gray-400">
-              Discover and collaborate on amce. Explore our services now.
+              Discover and collaborate on acme. Explore our services now.
             </Text>
 
             <View className="gap-4">


### PR DESCRIPTION
<img width="335" alt="image" src="https://github.com/expo/examples/assets/1793179/2ded35d8-694b-4639-854e-7f3e2b1f9148">
