### PR TITLE
fix: Add toggle to create TV build

### DIFF
--- a/with-tv/app.json
+++ b/with-tv/app.json
@@ -13,7 +13,8 @@
             "topShelf2x": "./assets/images/icon-3840x1440.png",
             "topShelfWide": "./assets/images/icon-2320x720.png",
             "topShelfWide2x": "./assets/images/icon-4640x1440.png"
-          }
+          },
+          "isTV": true
         }
       ]
     ]


### PR DESCRIPTION
Adding the isTV parameter to the plugin to create the TV build
https://docs.expo.dev/guides/building-for-tv/#add-the-tv-config-plugin 