### PR TITLE
Fix: Add scripts and modify README for tv examples

### DIFF
--- a/with-router-tv/README.md
+++ b/with-router-tv/README.md
@@ -1,7 +1,7 @@
 # Expo Router TV demo 👋
 
 ![Apple TV screen shot](https://github.com/douglowder/examples/assets/6577821/a881466f-a7a0-4c66-b1fc-33235c466997)
-![Android TV screen shot](https://github.com/douglowder/examples/assets/6577821/815c8e01-8275-4cc1-bd57-b9c8bce1fb02) 
+![Android TV screen shot](https://github.com/douglowder/examples/assets/6577821/815c8e01-8275-4cc1-bd57-b9c8bce1fb02)
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
@@ -20,6 +20,10 @@ yarn prebuild # Executes Expo prebuild with TV modifications
 yarn ios # Build and run for Apple TV
 yarn android # Build for Android TV
 ```
+
+> **_NOTE:_**
+> Setting the environment variable `EXPO_TV=1` enables the `@react-native-tvos/config-tv` plugin to modify the project for TV.
+> This can also be done by setting the parameter `isTV` to true in the `app.json`.
 
 ## Development
 

--- a/with-tv/README.md
+++ b/with-tv/README.md
@@ -21,10 +21,14 @@ yarn ios # Build for Apple TV
 yarn android # Build for Android TV
 ```
 
+> **_NOTE:_**
+> Setting the environment variable `EXPO_TV=1` enables the `@react-native-tvos/config-tv` plugin to modify the project for TV.
+> This can also be done by setting the parameter `isTV` to true in the `app.json`.
+
 #### TV specific file extensions
 
-This project contains an [example Metro configuration](./metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (`*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`).  This config is not enabled by default, since it will impact bundling performance, but is available for developers who need this capability.
+This project contains an [example Metro configuration](./metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (`*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`). This config is not enabled by default, since it will impact bundling performance, but is available for developers who need this capability.
 
 #### TV specific app icons and banners
 
-This project contains placeholder images for the Android TV banner and for Apple TV brand assets (app icon and top shelf images).  The `config-tv` plugin will use these images to construct the required native image files and make the right modifications in project files. You can simply replace these images with your own app images. Note that for Apple TV, the images must be the exact sizes indicated.
+This project contains placeholder images for the Android TV banner and for Apple TV brand assets (app icon and top shelf images). The `config-tv` plugin will use these images to construct the required native image files and make the right modifications in project files. You can simply replace these images with your own app images. Note that for Apple TV, the images must be the exact sizes indicated.

--- a/with-tv/package.json
+++ b/with-tv/package.json
@@ -1,6 +1,13 @@
 {
   "name": "with-tv",
   "version": "1.0.0",
+  "scripts": {
+    "start": "EXPO_TV=1 expo start",
+    "android": "EXPO_TV=1 expo run:android",
+    "ios": "EXPO_TV=1 expo run:ios",
+    "web": "expo start --web",
+    "prebuild": "EXPO_TV=1 expo prebuild --clean"
+  },
   "dependencies": {
     "expo": "~51.0.13",
     "expo-splash-screen": "~0.27.5",


### PR DESCRIPTION
Added the scripts for with-tv and modified the README to include a description of why the EXPO_TV=1 is needed.