### PR TITLE
Update with-aws-storage-upload App.js mediaTypes key

### DIFF
--- a/with-aws-storage-upload/App.js
+++ b/with-aws-storage-upload/App.js
@@ -33,7 +33,7 @@ export default function App() {
 
   const takePhoto = async () => {
     let result = await ImagePicker.launchCameraAsync({
-      mediaTypes: "Images",
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
       aspect: [4, 3],
     });
 


### PR DESCRIPTION
The possible options that can be assigned to the mediaType of the launchCameraAsync function now come from MediaTypeOptions props, which I have updated in this commit