### PR TITLE
fix(with-nextjs): transpile react-native-web to fix ssr styles

### DIFF
--- a/with-nextjs/next.config.js
+++ b/with-nextjs/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = withExpo({
   swcMinify: true,
   transpilePackages: [
     "react-native",
+    "react-native-web",
     "expo",
     // Add more React Native / Expo packages here...
   ],


### PR DESCRIPTION
# Description

Fixes an issue reported on the main expo's repo: https://github.com/expo/expo/issues/31272 

# Testing

Checkout the `ssr-issue-fix` which contains both the fix and a background color on the page (which isn't added to the example in the PR), used to verify the fix.

```bash
git clone git@github.com:illbexyz/examples.git \
&& cd examples \
&& git checkout ssr-issue-fix \
&& cd with-nextjs \
&& npm install
```

Start the example and verify that the styles are now being correctly added to the html document.

![image](https://github.com/user-attachments/assets/9df1cb2d-106c-4c65-810b-4c4b26d654f7)
![image](https://github.com/user-attachments/assets/6239db8d-f70c-48d3-873d-9ab6e082dda5)
![image](https://github.com/user-attachments/assets/7254dd3b-43c8-4703-97b6-e9d6c7ab647b)

