### PR TITLE
Fixed expo/examples/with-firebase-storage-upload incorrect asset reference

### DIFF
--- a/with-firebase-storage-upload/package.json
+++ b/with-firebase-storage-upload/package.json
@@ -8,7 +8,8 @@
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
     "react-native-web": "~0.19.6",
-    "uuid": "3.4.0"
+    "uuid": "3.4.0",
+    "expo-image-manipulator": "~12.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"


### PR DESCRIPTION
Hi,

First time PR to Expo.

I believe the asset reference in uploadImageAsync was incorrect. Fixed that, added a basic image manipulation example, some more verbose logging and fixed a minor spelling error.

Hope this helps.