### PR TITLE
Add ImageSource type to fix TypeScript issues where Expo Image is used

### DIFF
--- a/stickersmash/app/(tabs)/index.tsx
+++ b/stickersmash/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import * as MediaLibrary from "expo-media-library";
 import { captureRef } from "react-native-view-shot";
 import domtoimage from "dom-to-image";
+import { type ImageSource } from "expo-image";
 
 import Button from "@/components/Button";
 import ImageViewer from "@/components/ImageViewer";
@@ -22,7 +23,9 @@ export default function Index() {
   );
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
+  const [pickedEmoji, setPickedEmoji] = useState<ImageSource | undefined>(
+    undefined
+  );
   const [status, requestPermission] = MediaLibrary.usePermissions();
   const imageRef = useRef<View>(null);
 

--- a/stickersmash/components/EmojiList.tsx
+++ b/stickersmash/components/EmojiList.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { StyleSheet, FlatList, Platform, Pressable } from "react-native";
-import { Image } from "expo-image";
+import { Image, type ImageSource } from "expo-image";
 
 type Props = {
-  onSelect: (image: string) => void;
+  onSelect: (image: ImageSource) => void;
   onCloseModal: () => void;
 };
 
 export default function EmojiList({ onSelect, onCloseModal }: Props) {
-  const [emoji] = useState([
+  const [emoji] = useState<ImageSource[]>([
     require("../assets/images/emoji1.png"),
     require("../assets/images/emoji2.png"),
     require("../assets/images/emoji3.png"),

--- a/stickersmash/components/EmojiSticker.tsx
+++ b/stickersmash/components/EmojiSticker.tsx
@@ -1,14 +1,14 @@
-import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from "react-native-reanimated";
+import { type ImageSource } from "expo-image";
 
 type Props = {
   imageSize: number;
-  stickerSource: string;
+  stickerSource: ImageSource;
 };
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {

--- a/stickersmash/components/ImageViewer.tsx
+++ b/stickersmash/components/ImageViewer.tsx
@@ -1,8 +1,8 @@
 import { StyleSheet } from "react-native";
-import { Image } from "expo-image";
+import { Image, type ImageSource } from "expo-image";
 
 type Props = {
-  imgSource: string;
+  imgSource: ImageSource;
   selectedImage?: string;
 };
 


### PR DESCRIPTION
Follow-up [#32115](https://github.com/expo/expo/pull/32115)

Fix type missing issue when an image is used inside any custom component.