### PR TITLE
Fixed crash on with-realm example by updating realm to the latest community version (#415)

### DIFF
--- a/with-realm/package.json
+++ b/with-realm/package.json
@@ -1,16 +1,16 @@
 {
-  "scripts": {
-    "start": "expo start --dev-client",
-    "android": "expo run:android",
-    "ios": "expo run:ios"
-  },
-  "dependencies": {
-    "@realm/react": "^0.4.3",
-    "expo": "^52.0.16",
-    "expo-dev-client": "~5.0.5",
-    "react": "18.3.1",
-    "react-native": "0.76.3",
-    "react-native-get-random-values": "~1.11.0",
-    "realm": "^11.7.0"
-  }
+	"scripts": {
+		"start": "expo start --dev-client",
+		"android": "expo run:android",
+		"ios": "expo run:ios"
+	},
+	"dependencies": {
+		"@realm/react": "^0.11.0",
+		"expo": "^52.0.16",
+		"expo-dev-client": "~5.0.5",
+		"react": "18.3.1",
+		"react-native": "0.76.3",
+		"react-native-get-random-values": "~1.11.0",
+		"realm": "^20.1.0"
+	}
 }


### PR DESCRIPTION
Atlas Device Sync + Realm SDKs are deprecated. Used realm@community instead. Also upgraded @realm/react package to the latest version.

See npm package homepage for details:
https://www.npmjs.com/package/realm