### PR TITLE
TV router example to Expo 52.0.46, add web support

### DIFF
--- a/with-router-tv/README.md
+++ b/with-router-tv/README.md
@@ -19,6 +19,7 @@ yarn
 yarn prebuild # Executes Expo prebuild with TV modifications
 yarn ios # Build and run for Apple TV
 yarn android # Build for Android TV
+yarn web # Run the project on web from localhost
 ```
 
 > **_NOTE:_**
@@ -29,7 +30,7 @@ yarn android # Build for Android TV
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
-This project includes a [demo](./components/EventHandlingDemo.tsx)showing how to use React Native TV APIs to highlight controls as the user navigates the screen with the remote control.
+This project includes a [demo](./components/EventHandlingDemo.tsx) showing how to use React Native TV APIs to highlight controls as the user navigates the screen with the remote control.
 
 ## TV specific file extensions
 

--- a/with-router-tv/app.json
+++ b/with-router-tv/app.json
@@ -30,6 +30,11 @@
         "image": "./assets/images/splash.png"
       }
     },
+    "web": {
+      "bundler": "metro",
+      "favicon": "./assets/images/favicon.png",
+      "output": "static"
+    },
     "experiments": {
       "typedRoutes": true
     },

--- a/with-router-tv/app/(tabs)/_layout.tsx
+++ b/with-router-tv/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 import { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
 import { TabBarIcon } from '@/components/navigation/TabBarIcon';
 import { Colors } from '@/constants/Colors';
@@ -35,7 +35,8 @@ export default function TabLayout() {
         tabBarStyle: {
           height: textStyles.title.lineHeight * 2,
         },
-        tabBarPosition: 'top',
+        tabBarPosition:
+          Platform.isTV || Platform.OS === 'web' ? 'top' : 'bottom',
         tabBarIconStyle: {
           height: textStyles.title.lineHeight,
           width: 30 * scale,

--- a/with-router-tv/app/(tabs)/tv_focus.tsx
+++ b/with-router-tv/app/(tabs)/tv_focus.tsx
@@ -38,28 +38,26 @@ export default function FocusDemoScreen() {
           away from by the TV focus engine.
         </ThemedText>
         <ThemedText>
+          • On web, Pressable has the above handlers, and also has
+          "onHoverIn()", and "onHoverOut()" props.
+        </ThemedText>
+        <ThemedText>
           • In addition, the functional forms of the Pressable style prop and
           the Pressable content, which in React Native core take a "pressed"
           boolean parameter, can also take "focused" as a parameter on TV
-          platforms.
+          platforms, and "hovered" as a parameter on web.
         </ThemedText>
         <ThemedText>
           • As you use the arrow keys to navigate around the screen, the demo
           uses the above props to update lists of recent events.
         </ThemedText>
         <ThemedText>
-          In RNTV 0.76, `Pressable` and `Touchable` components receive "focus",
-          "blur", "pressIn", and "pressOut" events directly from native code,
-          for improved performance when navigating around the screen.
+          In RNTV 0.76 and above, `Pressable` and `Touchable` components receive
+          "focus", "blur", "pressIn", and "pressOut" events directly from native
+          code, for improved performance when navigating around the screen.
         </ThemedText>
       </Collapsible>
-      {Platform.isTV ? (
-        <EventHandlingDemo />
-      ) : (
-        <ThemedText>
-          Run this on Apple TV or Android TV to see the demo.
-        </ThemedText>
-      )}
+      <EventHandlingDemo />
     </ParallaxScrollView>
   );
 }

--- a/with-router-tv/components/EventHandlingDemo.tsx
+++ b/with-router-tv/components/EventHandlingDemo.tsx
@@ -2,7 +2,6 @@ import {
   StyleSheet,
   Text,
   View,
-  useTVEventHandler,
   Platform,
   Pressable,
   TouchableHighlight,
@@ -16,6 +15,15 @@ import { ThemedView } from '@/components/ThemedView';
 import { useScale } from '@/hooks/useScale';
 import { useThemeColor } from '@/hooks/useThemeColor';
 
+const useTVEventHandler = Platform.isTV
+  ? require('react-native').useTVEventHandler
+  : (_: any) => {};
+
+/**
+ * Demo of event handling on TV and web.
+ * On TV, the buttons will respond to focus, blur, and press events.
+ * On web, the buttons will respond to focus, blur, press, and hover events.
+ */
 export function EventHandlingDemo() {
   const [remoteEventLog, setRemoteEventLog] = useState<string[]>([]);
   const [pressableEventLog, setPressableEventLog] = useState<string[]>([]);
@@ -31,7 +39,7 @@ export function EventHandlingDemo() {
     setPressableEventLog((log) => logWithAppendedEntry(log, entry));
   };
 
-  useTVEventHandler((event) => {
+  useTVEventHandler((event: any) => {
     const { eventType, eventKeyAction } = event;
     if (eventType !== 'focus' && eventType !== 'blur') {
       setRemoteEventLog((log) =>
@@ -50,12 +58,14 @@ export function EventHandlingDemo() {
   return (
     <ThemedView style={styles.container}>
       <ThemedView style={styles.logContainer}>
-        <View>
-          <ThemedText type="defaultSemiBold">TV remote events</ThemedText>
-          <ThemedText style={styles.logText}>
-            {remoteEventLog.join('\n')}
-          </ThemedText>
-        </View>
+        {Platform.isTV && (
+          <View>
+            <ThemedText type="defaultSemiBold">TV remote events</ThemedText>
+            <ThemedText style={styles.logText}>
+              {remoteEventLog.join('\n')}
+            </ThemedText>
+          </View>
+        )}
         <View>
           <ThemedText type="defaultSemiBold">Native events</ThemedText>
           <ThemedText style={styles.logText}>
@@ -94,18 +104,28 @@ const PressableButton = (props: {
     <Pressable
       onFocus={() => props.log(`${props.title} onFocus`)}
       onBlur={() => props.log(`${props.title} onBlur`)}
+      onHoverIn={() => props.log(`${props.title} onHoverIn`)}
+      onHoverOut={() => props.log(`${props.title} onHoverOut`)}
       onPress={() => props.log(`${props.title} onPress`)}
       onPressIn={() => props.log(`${props.title} onPressIn`)}
       onPressOut={() => props.log(`${props.title} onPressOut`)}
       onLongPress={() => props.log(`${props.title} onLongPress`)}
-      style={({ pressed, focused }) =>
-        pressed || focused ? styles.pressableFocused : styles.pressable
+      style={({ pressed, focused, hovered }) =>
+        pressed || focused || hovered
+          ? styles.pressableFocused
+          : styles.pressable
       }
     >
-      {({ focused }) => {
+      {({ focused, hovered, pressed }) => {
         return (
           <ThemedText style={styles.pressableText}>
-            {focused ? `${props.title} focused` : props.title}
+            {pressed
+              ? `${props.title} pressed`
+              : focused
+              ? `${props.title} focused`
+              : hovered
+              ? `${props.title} hovered`
+              : props.title}
           </ThemedText>
         );
       }}
@@ -199,7 +219,7 @@ const useDemoStyles = function () {
     },
     logText: {
       maxHeight: 300 * scale,
-      width: 300 * scale,
+      width: Platform.isTV || Platform.OS === 'web' ? 300 * scale : 150 * scale,
       fontSize: 10 * scale,
       margin: 5 * scale,
       lineHeight: 12 * scale,

--- a/with-router-tv/package.json
+++ b/with-router-tv/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "expo": "~52.0.42",
+    "expo": "~52.0.46",
     "expo-build-properties": "~0.13.2",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",


### PR DESCRIPTION
Improve `with-router-tv` to support web, as well as TV and mobile targets.