### PR TITLE
add deploy command to all router projects and add deployment info

### DIFF
--- a/stickersmash/README.md
+++ b/stickersmash/README.md
@@ -20,6 +20,13 @@ Example code for "Get started tutorial" in Expo documentation.
   - Android: [Client Android](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=blankexample)
   - Web: Any web browser
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 Learn more about building **StickerSmash** app from scratch in [Get started with Expo tutorial](https://docs.expo.dev/tutorial/introduction/).

--- a/stickersmash/package.json
+++ b/stickersmash/package.json
@@ -1,7 +1,6 @@
 {
   "name": "stickersmash",
   "main": "expo-router/entry",
-  "version": "1.0.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -9,7 +8,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "jest": {
     "preset": "jest-expo"

--- a/with-maestro/README.md
+++ b/with-maestro/README.md
@@ -43,6 +43,13 @@
 
 > _Note:_ The Maestro flows in the [maestro/dev_build](./maestro/dev_build) folder must have the app's package name (Android) or bundle identifier (iOS) defined. To make this example work out of the box without changes, the [app.json](./app.json) and the Maestro flows for dev builds are preconfigured with these values set to `dev.expo.eastestsexample`. In your actual development, these should be changed to the correct values for your app.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Further information
 
 - [Expo guide on E2E tests with EAS](https://docs.expo.dev/build-reference/e2e-tests/)

--- a/with-maestro/package.json
+++ b/with-maestro/package.json
@@ -9,7 +9,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "jest": {
     "preset": "jest-expo"

--- a/with-openai/README.md
+++ b/with-openai/README.md
@@ -35,6 +35,13 @@ Replace `origin` in the `app.json` with the URL to your [production API Routes](
 
 Ensure you upload your environment variables to wherever you host the web app and API Routes.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 - [Expo Router: API Routes](https://docs.expo.dev/router/reference/api-routes/)

--- a/with-openai/package.json
+++ b/with-openai/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "expo": "^52.0.16",

--- a/with-react-flow/README.md
+++ b/with-react-flow/README.md
@@ -40,6 +40,13 @@ npx create-expo-app -e with-react-flow
 3. **Explore and Customize**  
    Navigate through the app using Expo Router and modify the provided flowchart components, styles, and routes.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## **📚 Tech Stack and Tools**
 
 ### **React Flow**

--- a/with-react-flow/package.json
+++ b/with-react-flow/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "@xyflow/react": "^12.1.1",

--- a/with-router-menus/README.md
+++ b/with-router-menus/README.md
@@ -23,6 +23,13 @@ npx create-expo-app -e with-router-menus
 - Run `npx expo run:ios` or `npx expo run:android` to build the project.
 - Open in the browser with `npx expo --web`.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## Zeego installation
 
 Run the following to add Zeego to an existing project:

--- a/with-router-menus/package.json
+++ b/with-router-menus/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",

--- a/with-router-tailwind/README.md
+++ b/with-router-tailwind/README.md
@@ -7,3 +7,10 @@ Use [Expo Router](https://docs.expo.dev/router/introduction/) with [Nativewind](
 ```sh
 npx create-expo-app -e with-router-tailwind
 ```
+
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)

--- a/with-router-tailwind/package.json
+++ b/with-router-tailwind/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "expo": "~52.0.27",

--- a/with-router-tv/README.md
+++ b/with-router-tv/README.md
@@ -32,6 +32,13 @@ You can start developing by editing the files inside the **app** directory. This
 
 This project includes a [demo](./components/EventHandlingDemo.tsx) showing how to use React Native TV APIs to highlight controls as the user navigates the screen with the remote control.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## TV specific file extensions
 
 This project includes an [example Metro configuration](./metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (`*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`). The [ExternalLink](./components/ExternalLink.tsx) component makes use of this by having a [separate TV source file](./components/ExternalLink.tv.tsx) that avoids importing packages that don't exist on Apple TV.

--- a/with-router-tv/package.json
+++ b/with-router-tv/package.json
@@ -10,7 +10,8 @@
     "reset-project": "./scripts/reset-project.js",
     "test": "jest --watchAll",
     "lint": "expo lint",
-    "prebuild": "EXPO_TV=1 expo prebuild --clean"
+    "prebuild": "EXPO_TV=1 expo prebuild --clean",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "jest": {
     "preset": "jest-expo"

--- a/with-router/README.md
+++ b/with-router/README.md
@@ -8,6 +8,13 @@ Use [`expo-router`](https://docs.expo.dev/router/introduction/) to build native 
 npx create-expo-app -e with-router
 ```
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 - [Expo Router: Docs](https://docs.expo.dev/router/introduction/)

--- a/with-router/package.json
+++ b/with-router/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "expo": "^52.0.16",

--- a/with-rsc/README.md
+++ b/with-rsc/README.md
@@ -8,6 +8,13 @@ Use [`expo-router`](https://docs.expo.dev/router/introduction/) with experimenta
 npx create-expo-app -e with-rsc
 ```
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 - [Expo Router: Docs](https://docs.expo.dev/router/introduction/)

--- a/with-rsc/package.json
+++ b/with-rsc/package.json
@@ -4,7 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "prepare": "npx patch-package"
+    "prepare": "npx patch-package",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "@types/react": "~18.3.12",

--- a/with-satori/README.md
+++ b/with-satori/README.md
@@ -32,6 +32,13 @@ Replace `origin` in the `app.json` with the URL to your [production API Routes](
 
 Ensure you upload your environment variables to wherever you host the web app and API Routes.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 - [Expo Router: API Routes](https://docs.expo.dev/router/reference/api-routes/)

--- a/with-satori/package.json
+++ b/with-satori/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "expo": "^52.0.16",

--- a/with-stripe/README.md
+++ b/with-stripe/README.md
@@ -28,6 +28,13 @@ This example shows how to use Stripe in your app and website.
 - Run `yarn start` or `npm run start` to start the bundler.
 - This example requires Expo API Routes to be deployed.
 
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)
+
 ## 📝 Notes
 
 - Learn more about [React Native Stripe](https://docs.stripe.com/payments/accept-a-payment?platform=react-native&ui=payment-sheet#react-native-customization).

--- a/with-stripe/package.json
+++ b/with-stripe/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "@react-navigation/native": "^7.0.0",

--- a/with-tailwindcss/README.md
+++ b/with-tailwindcss/README.md
@@ -7,3 +7,10 @@ Use [Expo Router](https://docs.expo.dev/router/introduction/) with [Nativewind](
 ```sh
 npx create-expo-app -e with-tailwindcss
 ```
+
+## Deploy
+
+Deploy on all platforms with Expo Application Services (EAS).
+
+- Deploy the website: `npx eas-cli deploy` — [Learn more](https://docs.expo.dev/eas/hosting/get-started/)
+- Deploy on iOS and Android using: `npx eas-cli build` — [Learn more](https://expo.dev/eas)

--- a/with-tailwindcss/package.json
+++ b/with-tailwindcss/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "deploy": "npx expo export -p web && npx eas-cli@latest deploy"
   },
   "dependencies": {
     "expo": "^52.0.16",


### PR DESCRIPTION
- Add deploy script to all router projects for web deployment.
- Add deployment section to readme of all router projects to add info about deploying the app/website.