### PR TITLE
Update TinyBase dependencies

### DIFF
--- a/with-tinybase/package.json
+++ b/with-tinybase/package.json
@@ -7,16 +7,13 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
-    "expo": "^53.0.4",
+    "expo": "^53.0.8",
     "expo-sqlite": "~15.2.9",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.1",
-    "react-native-safe-area-context": "5.3.0",
+    "react-native": "0.79.2",
+    "react-native-safe-area-context": "5.4.0",
     "react-native-web": "^0.20.0",
-    "tinybase": "^5.1.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
+    "tinybase": "^6.0.5"
   }
 }


### PR DESCRIPTION
Bumps a few dependencies (most importantly TinyBase itself) to enact v53 compatibility.