### PR TITLE
fix module "jwt-decode" having no default export for Auth0 example

### DIFF
--- a/with-auth0/App.js
+++ b/with-auth0/App.js
@@ -1,5 +1,5 @@
 import * as AuthSession from "expo-auth-session";
-import jwtDecode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 import { useEffect, useState } from "react";
 import { Alert, Button, Platform, StyleSheet, Text, View } from "react-native";
 

--- a/with-auth0/package.json
+++ b/with-auth0/package.json
@@ -2,11 +2,11 @@
   "dependencies": {
     "expo": "^53.0.4",
     "expo-auth-session": "~6.1.5",
-    "expo-random": "~14.0.1",
-    "jwt-decode": "2.2.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-native": "0.79.1",
+    "expo-crypto": "~14.1.4",
+    "jwt-decode": "^4.0.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-native": "0.79.2",
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
fix module "jwt-decode" having no default export to use `import { jwtDecode } from "jwt-decode"` instead