### PR TITLE
Fix example/with-camera: Camera re-initialization and Layout fix

### DIFF
--- a/with-camera/App.tsx
+++ b/with-camera/App.tsx
@@ -4,9 +4,10 @@ import {
   CameraView,
   useCameraPermissions,
 } from "expo-camera";
-import { useRef, useState } from "react";
+import { useRef, useState,useCallback } from "react";
 import { Button, Pressable, StyleSheet, Text, View } from "react-native";
 import { Image } from "expo-image";
+import { useFocusEffect } from "expo-router";
 import AntDesign from "@expo/vector-icons/AntDesign";
 import Feather from "@expo/vector-icons/Feather";
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
@@ -18,6 +19,14 @@ export default function App() {
   const [mode, setMode] = useState<CameraMode>("picture");
   const [facing, setFacing] = useState<CameraType>("back");
   const [recording, setRecording] = useState(false);
+  const [cameraKey, setCameraKey] = useState(0);
+  //Used to force CameraView re-mount on screen focus change
+	useFocusEffect(
+		useCallback(() => {
+			// Regenerate key when screen is focused
+			setCameraKey((prev) => prev + 1);
+		}, [])
+	);
 
   if (!permission) {
     return null;
@@ -73,48 +82,59 @@ export default function App() {
 
   const renderCamera = () => {
     return (
-      <CameraView
-        style={styles.camera}
-        ref={ref}
-        mode={mode}
-        facing={facing}
-        mute={false}
-        responsiveOrientationWhenOrientationLocked
-      >
-        <View style={styles.shutterContainer}>
-          <Pressable onPress={toggleMode}>
-            {mode === "picture" ? (
-              <AntDesign name="picture" size={32} color="white" />
-            ) : (
-              <Feather name="video" size={32} color="white" />
-            )}
-          </Pressable>
-          <Pressable onPress={mode === "picture" ? takePicture : recordVideo}>
-            {({ pressed }) => (
-              <View
-                style={[
-                  styles.shutterBtn,
-                  {
-                    opacity: pressed ? 0.5 : 1,
-                  },
-                ]}
-              >
-                <View
-                  style={[
-                    styles.shutterBtnInner,
-                    {
-                      backgroundColor: mode === "picture" ? "white" : "red",
-                    },
-                  ]}
-                />
-              </View>
-            )}
-          </Pressable>
-          <Pressable onPress={toggleFacing}>
-            <FontAwesome6 name="rotate-left" size={32} color="white" />
-          </Pressable>
-        </View>
-      </CameraView>
+      <>
+				<CameraView
+					key={cameraKey}
+					style={styles.camera}
+					ref={ref}
+					mode={mode}
+					facing={facing}
+					mute={false}
+					responsiveOrientationWhenOrientationLocked
+				/>
+				<View style={styles.shutterContainer}>
+					<Pressable onPress={toggleMode}>
+						{mode === "picture" ? (
+							<AntDesign name="picture" size={32} color="white" />
+						) : (
+							<Feather name="video" size={32} color="white" />
+						)}
+					</Pressable>
+					<Pressable
+						onPress={mode === "picture" ? takePicture : recordVideo}
+					>
+						{({ pressed }) => (
+							<View
+								style={[
+									styles.shutterBtn,
+									{
+										opacity: pressed ? 0.5 : 1,
+									},
+								]}
+							>
+								<View
+									style={[
+										styles.shutterBtnInner,
+										{
+											backgroundColor:
+												mode === "picture"
+													? "white"
+													: "red",
+										},
+									]}
+								/>
+							</View>
+						)}
+					</Pressable>
+					<Pressable onPress={toggleFacing}>
+						<FontAwesome6
+							name="rotate-left"
+							size={32}
+							color="white"
+						/>
+					</Pressable>
+				</View>
+			</>
     );
   };
 


### PR DESCRIPTION
This PR introduces two key improvements to the camera functionality in `with-camera/App.tsx`:


   1. Camera Re-initialization on Focus:
       * **Change**: Implemented `useFocusEffect` from `expo-router` to increment a `cameraKey` state variable whenever the
         screen gains focus. The `CameraView` component now uses this `cameraKey` as its key prop.
       * **Purpose**: This is an effective solution to ensure the `CameraView` component is re-mounted and
         re-initialized when the user navigates back to this screen. This addresses potential issues where the
         camera might not function correctly after being unfocused or backgrounded, providing a more robust user
         experience. The use of useCallback with useFocusEffect is also good practice for performance.


   2. `CameraView` Children Limitation Fix:
       * **Change**: The `CameraView` component and its associated shutter controls (View component) are now wrapped
         within a React Fragment (<></>).
       * **Purpose**: This correctly addresses the limitation that `CameraView` does not support children. By making
         the `CameraView` and the controls siblings within a fragment, you can then use absolute positioning for
         the controls, ensuring they render correctly on top of the camera feed without causing inconsistent
         behavior or crashes.
      * **Potential Fix** 
      
```bash
 WARN  The <CameraView> component does not support children. This may lead to inconsistent behaviour or crashes. If you want to render content on top of the Camera, consider using absolute positioning.
```