### PR TITLE
Update install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@
 Use this repo to create new React/React Native projects with [**create-expo**](https://github.com/expo/expo/tree/main/packages/create-expo#readme).
 
 ```sh
-npm create expo ./<path> --example <Example>
-npx create-expo ./<path> --example <Example>
+npx create-expo-app --example <Example>
+yarn create expo-app --example <Example>
+pnpm create expo-app --example <Example>
+bun create expo-app --example <Example>
 
 # Example - typescript
 
-npm create expo ./typescript-app --example with-typescript
-npx create-expo ./typescript-app --example with-typescript
+npx create-expo-app --example with-typescript
+yarn create expo-app --example with-typescript
+pnpm create expo-app --example with-typescript
+bun create expo-app --example with-typescript
 ```
 
 ## Contributors ✨

--- a/with-s3/README.md
+++ b/with-s3/README.md
@@ -9,7 +9,7 @@ https://github.com/user-attachments/assets/cca6e654-2862-48b0-9d29-92b5847d4ee9
 Create a new project with this example:
 
 ```sh
-npm create expo --example with-s3
+npx create-expo-app --example with-s3
 ```
 
 You may use credentials for an existing S3 bucket, or create a new one.

--- a/with-s3/package.json
+++ b/with-s3/package.json
@@ -23,7 +23,9 @@
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2"
+    "@babel/core": "^7.25.2",
+    "typescript": "~5.8.3",
+    "@types/react": "~19.0.10"
   },
   "private": true
 }


### PR DESCRIPTION
# Why

I copied the first command from the main readme without verifying it, but I just realised that does not actually work.

I think `npm create expo ./typescript-app --example with-typescript` is an older version of the command.
Currently it should be `npm create expo --example with-typescript typescript-app`

But as on the cli we removed npm all together (and just use npx) we can do the same.

Also added `bun`, `pnpm` and `yarn` commands.