### PR TITLE
Upgrade `with-webrtc` to use `react-native-webrtc` v124

### DIFF
--- a/with-webrtc/package.json
+++ b/with-webrtc/package.json
@@ -13,11 +13,11 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.1",
     "react-native-web": "^0.20.0",
-    "react-native-webrtc": "^106.0.6"
+    "react-native-webrtc": "^124.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
-    "@config-plugins/react-native-webrtc": "^6.0.0"
+    "@config-plugins/react-native-webrtc": "^12.0.0"
   },
   "name": "with-webrtc",
   "version": "1.0.0"


### PR DESCRIPTION
This PR upgrades the version of react-native-webrtc to a more recent version of v124, along with the version bump of the respective config-plugin to 12.0.0 (since version 11.0.0 doesn't exist as per the config plugin [table here](https://github.com/expo/config-plugins/tree/main/packages/react-native-webrtc#versioning))

### Why
 This version bump is needed to solve the desugaring option deprecation issue on Android.