### PR TITLE
Fix/with-apollo branch updates broken SWAPI endpoint, null checks, query schemas, updates to expo 54 and apollo 4.

### DIFF
--- a/with-apollo/README.md
+++ b/with-apollo/README.md
@@ -22,4 +22,4 @@
 
 - The Apollo configuration lies in the `apollo.js` file.
 - The file also contains an option (with commented code) to pass an authorization token to the API.
-- [Apollo Client Docs](https://www.apollographql.com/docs/react/v3.0-beta/)
+- [Apollo Client Docs](https://www.apollographql.com/docs/react/get-started/)

--- a/with-apollo/apollo.js
+++ b/with-apollo/apollo.js
@@ -1,8 +1,9 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
-// import { setContext } from '@apollo/link-context';
+// import { ApolloProvider, ApolloLink } from '@apollo/client';
+
 
 // see: https://github.com/graphql/swapi-graphql
-const GRAPHQL_API_URL = 'https://swapi-graphql.netlify.app/.netlify/functions/index';
+const GRAPHQL_API_URL = 'https://swapi-gql-wrapper.vercel.app/api/graphql';
 
 /*
 uncomment the code below in case you are using a GraphQL API that requires some form of
@@ -11,12 +12,15 @@ you provide while making the request.
 
 
 const TOKEN = '';
-const asyncAuthLink = setContext(async () => {
-  return {
+
+const authLink = new ApolloLink((operation, forward) => {
+  operation.setContext(({ headers = {} }) => ({
     headers: {
-      Authorization: TOKEN,
+      ...headers,
+      Authorization: TOKEN ? `Bearer ${TOKEN}` : '',
     },
-  };
+  }));
+  return forward(operation);
 });
 
 */
@@ -28,5 +32,5 @@ const httpLink = new HttpLink({
 export const apolloClient = new ApolloClient({
   cache: new InMemoryCache(),
   link: httpLink,
-  // link: asyncAuthLink.concat(httpLink),
+  // link: authLink.concat(httpLink),
 });

--- a/with-apollo/package.json
+++ b/with-apollo/package.json
@@ -1,13 +1,12 @@
 {
   "dependencies": {
-    "@apollo/client": "^3.4.16",
-    "@apollo/link-context": "^2.0.0-beta.3",
-    "@react-native-picker/picker": "2.11.1",
-    "expo": "^54.0.1",
-    "graphql": "^15.0.0",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "react-native": "0.81.4",
-    "react-native-web": "^0.21.0"
+    "@apollo/client": "^4.0.4",               
+    "@react-native-picker/picker": "latest", 
+    "expo": "^54.0.1",                   
+    "graphql": "^16.11.0",                    
+    "react": "19.1.0",                        
+    "react-dom": "19.1.0",                  
+    "react-native": "0.81.4",               
+    "react-native-web": "latest"             
   }
 }


### PR DESCRIPTION
I discovered some issued here https://github.com/expo/examples/issues/610. 

1. Original SWAPI endpoint was redirecting and losing POST query.  
2. Even the redirected endpoint did not have proper data such as manufactures etc.  
3. I created my own graphql wrapper around the REST based swapi.dev mirror https://swapi.py4e.com/api and updated with-apollo endpoint to mine. 
4. My wrapper API can be checked at https://github.com/AnupamKhosla/swapi-gql-wrapper. 
5. Apollo 3 is EOL outdated, so I changed that to the latest Apollo4, which requires `@apollo/client/react` in `import`.
6. I changed gql queries slightly to match my wrapper api.
7. I added some option chaining for null checks `data?.starshipById`.  
8. Update to Expo 54.