### PR TITLE
refactor: drop `@babel/core` as dependency for SDK 54

### DIFF
--- a/blank/package.json
+++ b/blank/package.json
@@ -5,8 +5,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/stickersmash/package.json
+++ b/stickersmash/package.json
@@ -46,7 +46,6 @@
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.1.10",
     "@types/react-test-renderer": "^18.3.0",

--- a/with-apollo/package.json
+++ b/with-apollo/package.json
@@ -9,8 +9,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-auth0/package.json
+++ b/with-auth0/package.json
@@ -8,8 +8,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-aws-storage-upload/package.json
+++ b/with-aws-storage-upload/package.json
@@ -14,8 +14,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-better-auth/package.json
+++ b/with-better-auth/package.json
@@ -34,7 +34,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@types/react": "~19.1.10",
     "jest": "^29.2.1",
     "jest-expo": "~54.0.10",

--- a/with-camera/package.json
+++ b/with-camera/package.json
@@ -15,7 +15,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-canary-react-19/package.json
+++ b/with-canary-react-19/package.json
@@ -19,7 +19,6 @@
     "typescript": "~5.9.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "@types/react-dom": "~19.1.7"
   },

--- a/with-custom-font/package.json
+++ b/with-custom-font/package.json
@@ -7,8 +7,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-drawer-navigation/package.json
+++ b/with-drawer-navigation/package.json
@@ -14,8 +14,5 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-facebook-auth/package.json
+++ b/with-facebook-auth/package.json
@@ -8,9 +8,6 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
   },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
-  },
   "scripts": {
     "start": "expo start"
   }

--- a/with-firebase-saml-login/package.json
+++ b/with-firebase-saml-login/package.json
@@ -12,7 +12,6 @@
     "react-native": "0.81.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "serve": "^13.0.2"
   }
 }

--- a/with-firebase-storage-upload/package.json
+++ b/with-firebase-storage-upload/package.json
@@ -9,8 +9,5 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0",
     "uuid": "3.4.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-formdata-image-upload/package.json
+++ b/with-formdata-image-upload/package.json
@@ -7,8 +7,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-google-vision/package.json
+++ b/with-google-vision/package.json
@@ -6,8 +6,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-graphql/package.json
+++ b/with-graphql/package.json
@@ -18,7 +18,6 @@
     "urql": "^4.2.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   },

--- a/with-icons/package.json
+++ b/with-icons/package.json
@@ -6,8 +6,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-legend-state-supabase/package.json
+++ b/with-legend-state-supabase/package.json
@@ -14,7 +14,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@types/react": "~19.1.10",
     "@types/uuid": "^10.0.0",
     "typescript": "~5.9.2"

--- a/with-libsql/package.json
+++ b/with-libsql/package.json
@@ -10,8 +10,5 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "typescript": "~5.9.2"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.20.0"
   }
 }

--- a/with-maestro/package.json
+++ b/with-maestro/package.json
@@ -33,7 +33,6 @@
     "react-native-screens": "~4.16.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.1.10",
     "@types/react-test-renderer": "^18.0.7",

--- a/with-magic/package.json
+++ b/with-magic/package.json
@@ -7,8 +7,5 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-maps/package.json
+++ b/with-maps/package.json
@@ -6,8 +6,5 @@
     "react-native": "0.81.4",
     "react-native-maps": "1.20.1",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-moti/package.json
+++ b/with-moti/package.json
@@ -7,8 +7,5 @@
     "react-native": "0.81.4",
     "react-native-reanimated": "~4.1.0",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-nextjs/package.json
+++ b/with-nextjs/package.json
@@ -8,7 +8,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@expo/next-adapter": "^6.0.0"
   },
   "scripts": {

--- a/with-openai/package.json
+++ b/with-openai/package.json
@@ -21,7 +21,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-pdf/package.json
+++ b/with-pdf/package.json
@@ -16,7 +16,6 @@
     "react-native-pdf": "^6.6.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@config-plugins/react-native-blob-util": "^0.0.0",
     "@config-plugins/react-native-pdf": "^0.0.0"
   }

--- a/with-processing/package.json
+++ b/with-processing/package.json
@@ -8,8 +8,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-react-compiler/package.json
+++ b/with-react-compiler/package.json
@@ -5,7 +5,6 @@
     "react-native": "0.81.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@types/react": "~19.1.10",
     "babel-plugin-react-compiler": "0.0.0-experimental-334f00b-20240725",
     "eslint": "^8.57.0",

--- a/with-react-flow/package.json
+++ b/with-react-flow/package.json
@@ -26,7 +26,6 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-react-router/package.json
+++ b/with-react-router/package.json
@@ -7,8 +7,5 @@
     "react-native-web": "^0.21.0",
     "react-router-dom": "5.3.0",
     "react-router-native": "5.2.1"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-react-strict-dom/package.json
+++ b/with-react-strict-dom/package.json
@@ -23,7 +23,6 @@
     "react-strict-dom": "^0.0.34"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@types/react": "~19.1.10",
     "autoprefixer": "^10.4.21",
     "postcss-react-strict-dom": "^0.0.6",

--- a/with-react-three-fiber/package.json
+++ b/with-react-three-fiber/package.json
@@ -14,7 +14,6 @@
     "three": "^0.145.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@expo/metro-runtime": "~6.1.1"
   }
 }

--- a/with-reanimated/package.json
+++ b/with-reanimated/package.json
@@ -8,8 +8,5 @@
     "react-native": "0.81.4",
     "react-native-reanimated": "~4.1.0",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-router-ai/package.json
+++ b/with-router-ai/package.json
@@ -32,7 +32,6 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-router-tailwind/package.json
+++ b/with-router-tailwind/package.json
@@ -24,7 +24,6 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-router-tv/package.json
+++ b/with-router-tv/package.json
@@ -35,7 +35,6 @@
     "react-native-worklets": "~0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@react-native-tvos/config-tv": "^0.1.4",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"

--- a/with-router/package.json
+++ b/with-router/package.json
@@ -20,8 +20,5 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.20.0"
   }
 }

--- a/with-rsc/package.json
+++ b/with-rsc/package.json
@@ -26,7 +26,6 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
-    "patch-package": "^8.0.0",
-    "@babel/core": "^7.20.0"
+    "patch-package": "^8.0.0"
   }
 }

--- a/with-s3/package.json
+++ b/with-s3/package.json
@@ -23,7 +23,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   },

--- a/with-satori/package.json
+++ b/with-satori/package.json
@@ -23,7 +23,6 @@
     "satori": "0.10.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-sentry/package.json
+++ b/with-sentry/package.json
@@ -6,8 +6,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-shadcn/package.json
+++ b/with-shadcn/package.json
@@ -37,7 +37,6 @@
     "vaul": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",

--- a/with-socket-io/package.json
+++ b/with-socket-io/package.json
@@ -6,8 +6,5 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0",
     "socket.io-client": "^4.3.2"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-splash-screen/package.json
+++ b/with-splash-screen/package.json
@@ -9,8 +9,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-sqlite/package.json
+++ b/with-sqlite/package.json
@@ -12,8 +12,5 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "typescript": "~5.9.2"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.20.0"
   }
 }

--- a/with-storybook/package.json
+++ b/with-storybook/package.json
@@ -12,7 +12,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@storybook/addon-essentials": "^7.4.6",
     "@storybook/addon-interactions": "^7.4.6",
     "@storybook/addon-links": "^7.4.6",

--- a/with-stripe/package.json
+++ b/with-stripe/package.json
@@ -30,7 +30,6 @@
     "stripe": "^16.11.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   },

--- a/with-styled-components/package.json
+++ b/with-styled-components/package.json
@@ -6,8 +6,5 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0",
     "styled-components": "^5.1.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-svg/package.json
+++ b/with-svg/package.json
@@ -9,7 +9,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@expo/metro-runtime": "~6.1.1"
   }
 }

--- a/with-tailwindcss/package.json
+++ b/with-tailwindcss/package.json
@@ -24,7 +24,6 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"
   }

--- a/with-tfjs-camera/package.json
+++ b/with-tfjs-camera/package.json
@@ -12,8 +12,5 @@
     "react-native": "0.81.4",
     "react-native-fs": "^2.16.6",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-three/package.json
+++ b/with-three/package.json
@@ -11,8 +11,5 @@
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0",
     "three": "^0.145.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-tv/package.json
+++ b/with-tv/package.json
@@ -20,7 +20,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
     "@react-native-tvos/config-tv": "^0.1.4",
     "@types/react": "~19.1.10",
     "typescript": "~5.9.2"

--- a/with-typescript/package.json
+++ b/with-typescript/package.json
@@ -7,7 +7,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@types/react": "~19.1.10",
     "@types/react-native": "~0.70.6",
     "typescript": "~5.9.2"

--- a/with-victory-native/package.json
+++ b/with-victory-native/package.json
@@ -10,7 +10,6 @@
     "victory-native": "^35.5.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@expo/metro-runtime": "~6.1.1"
   }
 }

--- a/with-video-background/package.json
+++ b/with-video-background/package.json
@@ -6,8 +6,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-webbrowser-redirect/package.json
+++ b/with-webbrowser-redirect/package.json
@@ -7,8 +7,5 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-web": "^0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.19.3"
   }
 }

--- a/with-workbox/package.json
+++ b/with-workbox/package.json
@@ -10,7 +10,6 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
     "@expo/webpack-config": "^19.0.0",
     "serve": "^12.0.0",
     "workbox-background-sync": "^6.1.5",

--- a/with-yarn-workspaces/apps/mobile/package.json
+++ b/with-yarn-workspaces/apps/mobile/package.json
@@ -18,8 +18,5 @@
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
     "react-native-web": "~0.19.6"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.24.0"
   }
 }


### PR DESCRIPTION
Supersedes #605
Closes #605