### PR TITLE
refactor(with-router): drop extraneous libraries

### DIFF
--- a/with-router/package.json
+++ b/with-router/package.json
@@ -8,17 +8,10 @@
   },
   "dependencies": {
     "expo": "^54.0.1",
-    "expo-constants": "~18.0.8",
-    "expo-linking": "~8.0.7",
     "expo-router": "~6.0.0",
-    "expo-splash-screen": "~31.0.8",
-    "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
-    "react-native-gesture-handler": "~2.28.0",
-    "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0"
   }
 }


### PR DESCRIPTION
These are installed as peer dependencies, it works fine in both Expo Go and Dev client.