### PR TITLE
chore(with-router-uniwind): upgrade to Expo SDK 55

### DIFF
--- a/with-router-uniwind/app.json
+++ b/with-router-uniwind/app.json
@@ -3,6 +3,9 @@
     "scheme": "acme",
     "userInterfaceStyle": "automatic",
     "orientation": "default",
+    "plugins": [
+      "expo-router"
+    ],
     "web": {
       "output": "static"
     }

--- a/with-router-uniwind/package.json
+++ b/with-router-uniwind/package.json
@@ -3,16 +3,20 @@
   "version": "1.0.0",
   "main": "expo-router/entry",
   "dependencies": {
-    "expo": "~54.0.22",
-    "expo-router": "~6.0.14",
-    "expo-status-bar": "~3.0.8",
-    "react": "~19.1.0",
-    "react-native": "0.81.5",
+    "expo": "^55.0.8",
+    "expo-constants": "~55.0.9",
+    "expo-linking": "~55.0.8",
+    "expo-router": "~55.0.7",
+    "expo-status-bar": "~55.0.4",
+    "react": "19.2.0",
+    "react-native": "0.83.2",
+    "react-native-safe-area-context": "~5.6.2",
+    "react-native-screens": "~4.23.0",
     "tailwindcss": "~4.1.16",
     "uniwind": "~1.0.0"
   },
   "devDependencies": {
-    "@types/react": "~19.1.0",
+    "@types/react": "~19.2.10",
     "typescript": "~5.9.2"
   }
 }


### PR DESCRIPTION
Update the template to the Expo SDK 55 dependency set.

Add the required expo-router config plugin and peer dependencies, and validate the result with expo-doctor.
