### PR TITLE
chore(🐙): update react-native-wgpu version to 0.5.11

### DIFF
--- a/with-webgpu/package.json
+++ b/with-webgpu/package.json
@@ -20,7 +20,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0",
-    "react-native-wgpu": "^0.4.1",
+    "react-native-wgpu": "^0.5.11",
     "react-native-worklets": "0.5.1",
     "three": "0.172.0",
     "wgpu-matrix": "^3.0.2"


### PR DESCRIPTION
v5 has been a substantial stability upgrade from v4