### PR TITLE
chore: update Expo upgrade workflow to continue to next on failure

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -23,12 +23,12 @@ jobs:
       pull-requests: write
     steps:
       - name: 🏗️ Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗️ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/upgrade-dependencies.sh
+++ b/upgrade-dependencies.sh
@@ -26,6 +26,11 @@ if [ "$1" == "--upgrade-expo" ]; then
     DIRNAME=${d%/}
     echo "Upgrading $DIRNAME..."
 
+    if [ "$DIRNAME" == "with-tv" ] || [ "$DIRNAME" == "with-router-tv" ]; then
+      echo "$DIRNAME requires manual attention"
+      continue
+    fi
+
     if [ -z ${CI} ]; then
       echo "• Run $manager install";
       (cd $DIRNAME && $manager install --ignore-scripts &> ../.sdk-upgrade-logs/$DIRNAME-install.txt || echo "FAILURE")
@@ -35,8 +40,8 @@ if [ "$1" == "--upgrade-expo" ]; then
       exitCode=$?
       echo "::endgroup::"
       if [ $exitCode -ne 0 ]; then
-        echo -e "\033[0;31mFAILURE\033[0m";
-        continue;
+        echo -e "\033[0;31mFAILURE\033[0m"
+        continue
       fi
     fi
 
@@ -49,8 +54,8 @@ if [ "$1" == "--upgrade-expo" ]; then
       exitCode=$?
       echo "::endgroup::"
       if [ $exitCode -ne 0 ]; then
-        echo -e "\033[0;31mFAILURE\033[0m";
-        continue;
+        echo -e "\033[0;31mFAILURE\033[0m"
+        continue
       fi
     fi
   done
@@ -68,8 +73,8 @@ if [ "$1" == "--upgrade-expo" ]; then
       exitCode=$?
       echo "::endgroup::"
       if [ $exitCode -ne 0 ]; then
-        echo -e "\033[0;31mFAILURE\033[0m";
-        continue;
+        echo -e "\033[0;31mFAILURE\033[0m"
+        continue
       fi
     fi
 
@@ -82,8 +87,8 @@ if [ "$1" == "--upgrade-expo" ]; then
       exitCode=$?
       echo "::endgroup::"
       if [ $exitCode -ne 0 ]; then
-        echo -e "\033[0;31mFAILURE\033[0m";
-        continue;
+        echo -e "\033[0;31mFAILURE\033[0m"
+        continue
       fi
     fi
   done

--- a/upgrade-dependencies.sh
+++ b/upgrade-dependencies.sh
@@ -34,7 +34,10 @@ if [ "$1" == "--upgrade-expo" ]; then
       (cd $DIRNAME && $manager install --ignore-scripts)
       exitCode=$?
       echo "::endgroup::"
-      if [ $exitCode -ne 0 ]; then echo -e "\033[0;31mFAILURE\033[0m"; fi
+      if [ $exitCode -ne 0 ]; then
+        echo -e "\033[0;31mFAILURE\033[0m";
+        continue;
+      fi
     fi
 
     if [ -z ${CI} ]; then
@@ -45,7 +48,10 @@ if [ "$1" == "--upgrade-expo" ]; then
       (cd $DIRNAME && $manager add expo@$expoVersion && $manager expo install --fix)
       exitCode=$?
       echo "::endgroup::"
-      if [ $exitCode -ne 0 ]; then echo -e "\033[0;31mFAILURE\033[0m"; fi
+      if [ $exitCode -ne 0 ]; then
+        echo -e "\033[0;31mFAILURE\033[0m";
+        continue;
+      fi
     fi
   done
 
@@ -61,7 +67,10 @@ if [ "$1" == "--upgrade-expo" ]; then
       (cd $DIRNAME && yarn install)
       exitCode=$?
       echo "::endgroup::"
-      if [ $exitCode -ne 0 ]; then echo -e "\033[0;31mFAILURE\033[0m"; fi
+      if [ $exitCode -ne 0 ]; then
+        echo -e "\033[0;31mFAILURE\033[0m";
+        continue;
+      fi
     fi
 
     if [ -z ${CI} ]; then
@@ -72,7 +81,10 @@ if [ "$1" == "--upgrade-expo" ]; then
       (cd $DIRNAME && yarn add expo@$expoVersion && yarn expo install --fix)
       exitCode=$?
       echo "::endgroup::"
-      if [ $exitCode -ne 0 ]; then echo -e "\033[0;31mFAILURE\033[0m"; fi
+      if [ $exitCode -ne 0 ]; then
+        echo -e "\033[0;31mFAILURE\033[0m";
+        continue;
+      fi
     fi
   done
 


### PR DESCRIPTION
This is to unblock the current workflow halting on the upgrade when install failed.