### PR TITLE
Update with-widgets to support clear and tinted system appearance

### DIFF
--- a/with-widgets/widgets/MyWidget.tsx
+++ b/with-widgets/widgets/MyWidget.tsx
@@ -21,10 +21,14 @@ type MyWidgetProps = {
 
 const MyWidget = (props: MyWidgetProps, environment: WidgetEnvironment) => {
   'widget';
+  // Only show the full-color background in fullColor mode (or if undefined).
+  const isFullColor =
+    environment.widgetRenderingMode == null || environment.widgetRenderingMode === 'fullColor';
   return (
     <ZStack
       alignment="leading"
       modifiers={[containerBackground('#000000', 'widget'), clipShape('containerRelativeShape')]}>
+
 
       <ZStack
         alignment="bottomTrailing"
@@ -33,17 +37,19 @@ const MyWidget = (props: MyWidgetProps, environment: WidgetEnvironment) => {
           clipShape('containerRelativeShape'),
           zIndex(0),
         ]}>
-        <Rectangle
-          modifiers={[
-            foregroundStyle({
-              type: 'linearGradient',
-              colors: ['#58BEF6', '#366DF2'],
-              startPoint: { x: 0.5, y: 0 },
-              endPoint: { x: 0.5, y: 1 },
-            }),
-            frame({ maxWidth: Infinity, maxHeight: Infinity }),
-          ]}
-        />
+        {isFullColor && (
+          <Rectangle
+            modifiers={[
+              foregroundStyle({
+                type: 'linearGradient',
+                colors: ['#58BEF6', '#366DF2'],
+                startPoint: { x: 0.5, y: 0 },
+                endPoint: { x: 0.5, y: 1 },
+              }),
+              frame({ maxWidth: Infinity, maxHeight: Infinity }),
+            ]}
+          />
+        )}
 
         {props.gridUri && (
           <Image


### PR DESCRIPTION
## Why

The iOS widget showed correctly in full-color but was **completely covered** in iOS 18+ tinted/clear modes. The full-bleed gradient `Rectangle` was drawn as
regular content (not the container background), so WidgetKit re-rendered it as an opaque monochrome block that buried the text.

## How

Gate the gradient behind the rendering mode (in `widgets/MyWidget.tsx`):

```ts
const isFullColor =
  environment.widgetRenderingMode == null || environment.widgetRenderingMode === 'fullColor';
```

In tinted/clear modes the gradient is skipped and the existing containerBackground shows through, so text stays readable. Full-color mode is unchanged.

## Example

![CleanShot 2026-06-15 at 10.08.51.png](https://app.graphite.com/user-attachments/assets/a9f6049b-8ef0-4f33-96b2-e8a8b05c1066.png)