### PR TITLE
Add delivery Live Activity to with-widgets example

### DIFF
--- a/with-widgets/App.tsx
+++ b/with-widgets/App.tsx
@@ -1,10 +1,23 @@
 import { Asset } from 'expo-asset';
 import { File } from 'expo-file-system';
 import { widgetsDirectory } from 'expo-widgets';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
-import MyWidget from './widgets/MyWidget';
+import DeliveryActivity, { type DeliveryProps } from './widgets/DeliveryActivity';
+import CounterWidget from './widgets/CounterWidget';
+
+// Fake delivery stages the Live Activity steps through automatically. One stage
+// advances every ADVANCE_MS: Preparing -> +5 min On the way -> +5 min Delivered.
+const STAGES: DeliveryProps['status'][] = ['Preparing', 'On the way', 'Delivered'];
+const ADVANCE_MS = 5 * 60 * 1000;
+// The widget counts down to the arrival time and fills its progress bar across
+// this window on its own. Derive it from ADVANCE_MS so the countdown always hits
+// 0 exactly when the final stage lands — reaching "Delivered" takes one advance
+// per transition (STAGES.length - 1).
+const ETA_MS = ADVANCE_MS * (STAGES.length - 1);
+// How long to leave the finished "Delivered" state on screen before dismissing.
+const DELIVERED_LINGER_MS = 3 * 1000;
 
 // Widgets run in a separate process, so any image the widget renders has to
 // live in the shared app group container (`widgetsDirectory`) where the widget
@@ -24,6 +37,9 @@ async function ensureImageInSharedStorage(
 export default function App() {
   const [count, setCount] = useState(0);
   const [imageUris, setImageUris] = useState<{ logoUri: string; gridUri: string }>();
+  const [deliveryRunning, setDeliveryRunning] = useState(false);
+  const activityRef = useRef<ReturnType<typeof DeliveryActivity.start> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -32,7 +48,7 @@ export default function App() {
     ]).then(([logoUri, gridUri]) => {
       setImageUris({ logoUri, gridUri });
       // Push an initial snapshot so the widget has content to render
-      MyWidget.updateSnapshot({ count: 0, logoUri, gridUri });
+      CounterWidget.updateSnapshot({ count: 0, logoUri, gridUri });
     });
   }, []);
 
@@ -43,9 +59,64 @@ export default function App() {
     // must be included in every update. Skip the widget update until the
     // images are ready, otherwise this would blank them out.
     if (imageUris) {
-      MyWidget.updateSnapshot({ count: nextCount, ...imageUris });
+      CounterWidget.updateSnapshot({ count: nextCount, ...imageUris });
     }
   };
+
+  const propsForStage = (
+    stage: number,
+    startEpochMs: number,
+    etaEpochMs: number,
+  ): DeliveryProps => ({
+    orderId: '1234',
+    status: STAGES[stage],
+    stage,
+    startEpochMs,
+    etaEpochMs,
+    logoUri: imageUris?.logoUri,
+  });
+
+  const startDelivery = () => {
+    if (!imageUris || deliveryRunning) return; // need the shared logo first
+    try {
+      // Fixed start/arrival times for the whole run: the widget counts the ETA
+      // down and fills the progress bar across this window on its own.
+      const startEpochMs = Date.now();
+      const etaEpochMs = startEpochMs + ETA_MS;
+      activityRef.current = DeliveryActivity.start(propsForStage(0, startEpochMs, etaEpochMs));
+      setDeliveryRunning(true);
+      let stage = 0;
+      intervalRef.current = setInterval(() => {
+        stage += 1;
+        // Advance via update() — including the final 'Delivered' stage, since
+        // end()'s content argument isn't reliably rendered on its own.
+        activityRef.current?.update(propsForStage(stage, startEpochMs, etaEpochMs));
+        if (stage >= STAGES.length - 1) {
+          // 'Delivered' is now showing. Stop advancing and dismiss after a short
+          // linger so the finished state stays on screen briefly.
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          intervalRef.current = null;
+          setDeliveryRunning(false);
+          setTimeout(() => {
+            activityRef.current?.end('default');
+            activityRef.current = null;
+          }, DELIVERED_LINGER_MS);
+        }
+      }, ADVANCE_MS);
+    } catch (e) {
+      // Live Activities require iOS 16.2+ and the user to have them enabled.
+      console.warn('Could not start Live Activity', e);
+    }
+  };
+
+  // Cleanup on unmount: stop the timer and end any running activity.
+  useEffect(
+    () => () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      activityRef.current?.end('immediate');
+    },
+    [],
+  );
 
   return (
     <View style={styles.container}>
@@ -53,7 +124,16 @@ export default function App() {
       <Text style={styles.count}>Count: {count}</Text>
       <Button title="Increment and update widget" onPress={increment} />
       <Text style={styles.hint}>
-        Add "My Widget" to your home screen, then tap the button to update it.
+        Add "Counter Widget" to your home screen, then tap the button to update it.
+      </Text>
+      <Button
+        title={deliveryRunning ? 'Delivery in progress…' : 'Start delivery Live Activity'}
+        onPress={startDelivery}
+        disabled={deliveryRunning || !imageUris}
+      />
+      <Text style={styles.hint}>
+        Starts a Live Activity that auto-advances through delivery stages on the Lock Screen and
+        Dynamic Island, then dismisses itself.
       </Text>
     </View>
   );

--- a/with-widgets/README.md
+++ b/with-widgets/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-This example shows how to build an iOS home screen widget with [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) and update its data from the app.
+This example shows how to build an iOS home screen widget and a delivery Live Activity with [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/), and update them from the app.
 
 ## Launch your own
 
@@ -19,13 +19,15 @@ This example shows how to build an iOS home screen widget with [`expo-widgets`](
 
 - Install packages with `yarn` or `npm install`.
 - Run `yarn ios` or `npm run ios` to build and open the app on an iOS simulator or device.
-- Long-press the home screen, tap the **Edit** (or **+**) button, search for the app, and add **My Widget**.
-- Tap the button in the app and watch the widget update.
+- Long-press the home screen, tap the **Edit** (or **+**) button, search for the app, and add **Counter Widget**.
+- Tap **Increment and update widget** in the app and watch the widget update.
+- Tap **Start delivery Live Activity** to kick off a Live Activity that auto-advances Preparing → On the way → Delivered on the Lock Screen and Dynamic Island, with a live ETA countdown and a self-filling progress bar.
 
 ## 📝 Notes
 
 - Learn more about [Expo Widgets](https://docs.expo.dev/versions/latest/sdk/widgets/), including timelines and [Live Activities](https://docs.expo.dev/versions/latest/sdk/widgets/#live-activities).
-- The widget UI in [`widgets/MyWidget.tsx`](./widgets/MyWidget.tsx) is built with [`@expo/ui`](https://docs.expo.dev/versions/latest/sdk/ui/) SwiftUI primitives and the `'widget'` directive, and is registered with the `expo-widgets` config plugin in [`app.json`](./app.json).
+- The home screen widget UI in [`widgets/CounterWidget.tsx`](./widgets/CounterWidget.tsx) is built with [`@expo/ui`](https://docs.expo.dev/versions/latest/sdk/ui/) SwiftUI primitives and the `'widget'` directive, and is registered with the `expo-widgets` config plugin in [`app.json`](./app.json).
+- The delivery Live Activity in [`widgets/DeliveryActivity.tsx`](./widgets/DeliveryActivity.tsx) uses `createLiveActivity` to render a Lock Screen banner and the Dynamic Island presentations. Its ETA countdown and progress bar update on their own via SwiftUI `timerInterval`, so the app only pushes a snapshot when the delivery stage changes — see `startDelivery` in [`App.tsx`](./App.tsx).
 - The background is a `Rectangle` filled with the `foregroundStyle` modifier's `linearGradient` style, layered with a grid image in a `ZStack` behind the content and clipped with `clipShape('containerRelativeShape')` — see the [`@expo/ui` modifiers](https://docs.expo.dev/versions/latest/sdk/ui/#modifiers) for the other gradient types.
 - Widgets run in a separate process and cannot read the app's asset bundle, so the logo and grid images are copied into `widgetsDirectory` (the shared app group container) and referenced by their file URIs — see `ensureImageInSharedStorage` in [`App.tsx`](./App.tsx).
 
@@ -33,8 +35,9 @@ This example shows how to build an iOS home screen widget with [`expo-widgets`](
 
 ```
 with-widgets
-├── App.tsx ➡️ The app screen that updates the widget with `updateSnapshot`
-├── widgets/MyWidget.tsx ➡️ The widget UI, written with @expo/ui SwiftUI components
+├── App.tsx ➡️ The app screen that updates the widget and runs the Live Activity
+├── widgets/CounterWidget.tsx ➡️ The home screen widget UI, written with @expo/ui SwiftUI components
+├── widgets/DeliveryActivity.tsx ➡️ The delivery Live Activity UI (Lock Screen + Dynamic Island)
 ├── assets/images ➡️ Logo and grid images shared with the widget through `widgetsDirectory`
 └── app.json ➡️ The `expo-widgets` config plugin configuration
 ```

--- a/with-widgets/app.json
+++ b/with-widgets/app.json
@@ -6,10 +6,10 @@
         {
           "widgets": [
             {
-              "name": "MyWidget",
+              "name": "CounterWidget",
               "contentMarginsDisabled": true,
-              "displayName": "My Widget",
-              "description": "A sample home screen widget",
+              "displayName": "Counter Widget",
+              "description": "A sample counter home screen widget",
               "supportedFamilies": [
                 "systemSmall",
                 "systemMedium"

--- a/with-widgets/widgets/CounterWidget.tsx
+++ b/with-widgets/widgets/CounterWidget.tsx
@@ -13,13 +13,13 @@ import {
 } from '@expo/ui/swift-ui/modifiers';
 import { createWidget, type WidgetEnvironment } from 'expo-widgets';
 
-type MyWidgetProps = {
+type CounterWidgetProps = {
   count: number;
   logoUri?: string;
   gridUri?: string;
 };
 
-const MyWidget = (props: MyWidgetProps, environment: WidgetEnvironment) => {
+const CounterWidget = (props: CounterWidgetProps, environment: WidgetEnvironment) => {
   'widget';
   // Only show the full-color background in fullColor mode (or if undefined).
   const isFullColor =
@@ -99,4 +99,4 @@ const MyWidget = (props: MyWidgetProps, environment: WidgetEnvironment) => {
   );
 };
 
-export default createWidget('MyWidget', MyWidget);
+export default createWidget('CounterWidget', CounterWidget);

--- a/with-widgets/widgets/DeliveryActivity.tsx
+++ b/with-widgets/widgets/DeliveryActivity.tsx
@@ -1,0 +1,202 @@
+import { Capsule, HStack, Image, ProgressView, Spacer, Text, VStack, ZStack } from '@expo/ui/swift-ui';
+import {
+  clipShape,
+  containerBackground,
+  font,
+  foregroundStyle,
+  frame,
+  labelsHidden,
+  lineLimit,
+  ModifierConfig,
+  monospacedDigit,
+  multilineTextAlignment,
+  padding,
+  progressViewStyle,
+  resizable,
+  tint,
+} from '@expo/ui/swift-ui/modifiers';
+import { createLiveActivity, type LiveActivityEnvironment } from 'expo-widgets';
+import type { SFSymbol } from 'sf-symbols-typescript';
+
+export type DeliveryProps = {
+  orderId: string;
+  status: string; // 'Preparing' | 'On the way' | 'Delivered'
+  stage: number; // 0..2
+  // Props are JSON-serialized across the bridge, so pass epoch ms (not Date
+  // objects) and rebuild the Dates inside the widget.
+  startEpochMs: number;
+  etaEpochMs: number;
+  logoUri?: string;
+};
+
+// Layout helpers must live *inside* this function: the `'widget'` directive
+// serializes only the function body into the widget's separate JS runtime.
+const DeliveryActivity = (props: DeliveryProps, _env: LiveActivityEnvironment) => {
+  'widget';
+  const TOTAL_STAGES = 3;
+  const ACCENT = '#58BEF6';
+  const DIM = '#FFFFFF40';
+  // SF Symbols for each delivery step, shown in the expanded stepper.
+  const STEP_ICONS = ['bag.fill', 'box.truck.fill', 'house.fill'] as const;
+  // Rebuild the Dates from the epoch ms passed across the bridge.
+  const startDate = new Date(props.startEpochMs);
+  const etaDate = new Date(props.etaEpochMs);
+
+  // Shared app-group image (copied into widgetsDirectory by the app).
+  const Logo = ({ uri, size, modifiers }: { uri?: string; size?: number, modifiers?: ModifierConfig[] }) =>
+    uri ? (
+      <Image
+        uiImage={uri}
+        modifiers={[resizable(), frame({ width: size ?? 16, height: (size ?? 16) * 0.875 }), ...(modifiers ?? [])]}
+      />
+    ) : null;
+
+  // Stepped progress bar: SF Symbol milestones joined by connectors that fill on
+  // their own. Each connector is a ProgressView with a `timerInterval` for its
+  // slice of the [start, eta] window (countsDown: false → fills); `labelsHidden`
+  // hides the built-in timer text. A DIM Capsule sits behind each bar so the
+  // unfilled track reads muted — a linear ProgressView's track isn't recolorable,
+  // but it's translucent enough for the Capsule to show through. `accent` is white
+  // on the banner's blue gradient, the blue ACCENT on the dark island.
+  const StepProgress = ({ stage, accent = ACCENT }: { stage: number; accent?: string }) => {
+    // 3 stages -> 2 connectors, each spanning an equal slice of the window.
+    const segMs = (props.etaEpochMs - props.startEpochMs) / (TOTAL_STAGES - 1);
+    const cells = STEP_ICONS.flatMap((icon, i) => {
+      const step = <Image key={`s${i}`} systemName={icon} size={16} color="#FFFFFF" />;
+      if (i === STEP_ICONS.length - 1) return [step];
+      const connector = (
+        <ZStack key={`l${i}`} modifiers={[frame({ maxWidth: Infinity })]}>
+          <Capsule modifiers={[foregroundStyle(DIM), frame({ height: 4, maxWidth: Infinity })]} />
+          <ProgressView
+            timerInterval={{
+              lower: new Date(props.startEpochMs + i * segMs),
+              upper: new Date(props.startEpochMs + (i + 1) * segMs),
+            }}
+            countsDown={false}
+            modifiers={[
+              progressViewStyle('linear'),
+              // Finished connectors go white (like the icons); the filling one is accent.
+              tint(stage > i ? '#FFFFFF' : accent),
+              labelsHidden(),
+              frame({ maxWidth: Infinity }),
+            ]}
+          />
+        </ZStack>
+      );
+      return [step, connector];
+    });
+    return (
+      <HStack spacing={8} modifiers={[frame({ maxWidth: Infinity })]}>
+        {cells}
+      </HStack>
+    );
+  };
+
+  // Live countdown that updates on its own. A bounded `timerInterval` clamps at
+  // 0:00 (the `.timer` date style would count back up past the deadline); it swaps
+  // to a static label/icon once delivered. Timer text is greedy, so a fixed-width
+  // `frame` + `monospacedDigit` keep it from overflowing its region.
+  const Eta = ({
+    start,
+    end,
+    stage,
+    size,
+    color,
+    width,
+    deliveredLabel = 'Delivered',
+    deliveredIcon,
+  }: {
+    start: Date;
+    end: Date;
+    stage: number;
+    size: number;
+    color: string;
+    width: number;
+    deliveredLabel?: string;
+    // SF Symbol shown instead of the label once delivered (for the tiny compact region).
+    deliveredIcon?: SFSymbol;
+  }) =>
+    stage >= TOTAL_STAGES - 1 ? (
+      deliveredIcon ? (
+        // Larger than the countdown text it replaces, so it reads in the compact region.
+        <Image systemName={deliveredIcon} size={Math.round(size * 1.6)} color={color} />
+      ) : (
+        <Text modifiers={[font({ weight: 'medium', size }), foregroundStyle(color)]}>
+          {deliveredLabel}
+        </Text>
+      )
+    ) : (
+      <Text
+        timerInterval={{ lower: start, upper: end }}
+        countsDown
+        modifiers={[
+          font({ weight: 'medium', size }),
+          monospacedDigit(),
+          foregroundStyle(color),
+          multilineTextAlignment('trailing'),
+          frame({ width, alignment: 'trailing' }),
+        ]}
+      />
+    );
+
+  const statusLine = (p: DeliveryProps) =>
+    ['Packing your order now', 'Your order is on the way', 'Delivered — enjoy!'][p.stage] ?? p.status;
+
+  return {
+    // Lock screen / Notification Center banner.
+    banner: (
+      <ZStack
+        modifiers={[containerBackground('#000000', 'widget'), clipShape('containerRelativeShape')]}>
+
+        <VStack
+          alignment="leading"
+          spacing={12}
+          modifiers={[frame({ maxWidth: Infinity, alignment: 'leading' }), padding({ all: 16 })]}>
+          <HStack spacing={8}>
+            <Logo uri={props.logoUri} />
+            <Text modifiers={[font({ weight: 'medium', size: 13 }), foregroundStyle('#FFFFFF')]}>
+              Expo Starter
+            </Text>
+            <Spacer />
+            <HStack spacing={4}>
+              <Eta start={startDate} end={etaDate} stage={props.stage} size={13} color="#FFFFFFCC" width={48} />
+            </HStack>
+          </HStack>
+          <Text modifiers={[font({ weight: 'bold', size: 18 }), foregroundStyle('#FFFFFF')]}>
+            {props.status}
+          </Text>
+          <StepProgress stage={props.stage} accent="#FFFFFF" />
+        </VStack>
+      </ZStack>
+    ),
+    // Dynamic Island compact — leading = logo, trailing = ETA.
+    compactLeading: <Logo uri={props.logoUri} size={14} modifiers={[padding({ leading: 4 })]} />,
+    compactTrailing: (
+      <Eta start={startDate} end={etaDate} stage={props.stage} size={13} color="#FFFFFF" width={46} deliveredIcon="checkmark.circle.fill" />
+    ),
+    // Minimal — just the logo in the tiny minimal region.
+    minimal: <Logo uri={props.logoUri} size={16} />,
+    // Expanded — logo (top-left), ETA (top-right), progress bar across the bottom.
+    expandedLeading: (
+      <HStack spacing={6} modifiers={[padding({ leading: 8 })]}>
+        <Logo uri={props.logoUri} />
+        <Text modifiers={[font({ weight: 'semibold', size: 14 }), foregroundStyle('#FFFFFF'), lineLimit(1)]}>
+          Starter
+        </Text>
+      </HStack>
+    ),
+    expandedTrailing: (
+      <HStack modifiers={[padding({ trailing: 6 })]}>
+        <Eta start={startDate} end={etaDate} stage={props.stage} size={14} color={ACCENT} width={52} />
+      </HStack>
+    ),
+    expandedBottom: (
+      <VStack alignment="leading" spacing={10} modifiers={[padding({ top: 4, horizontal: 6 })]}>
+        <Text modifiers={[font({ size: 13 }), foregroundStyle('#FFFFFFCC')]}>{statusLine(props)}</Text>
+        <StepProgress stage={props.stage} />
+      </VStack>
+    ),
+  };
+};
+
+export default createLiveActivity<DeliveryProps>('DeliveryActivity', DeliveryActivity);


### PR DESCRIPTION
## Summary

Adds a delivery **Live Activity** to the `with-widgets` example and renames the existing home screen widget for clarity.

- Renamed `MyWidget.tsx` → `CounterWidget.tsx`.
- New `widgets/DeliveryActivity.tsx`: a `createLiveActivity` UI rendering a Lock Screen banner and the Dynamic Island (compact / minimal / expanded)
presentations.
- Auto-advances through stages: **Preparing → On the way → Delivered**, driven from `App.tsx` on a timer.
- ETA countdown and the stepped progress bar update on their own via SwiftUI `timerInterval` — the app only pushes a snapshot when the stage changes. The
countdown clamps at 0:00 (no counting back up) and swaps to a checkmark / "Delivered" state.
- `ETA_MS` is derived from `ADVANCE_MS` so the countdown always ends exactly when the final stage lands.
- Updated `README.md` to document the Live Activity and the renamed widget.

## Preview

![CleanShot 2026-06-15 at 21.54.37.png](https://app.graphite.com/user-attachments/assets/c2c5a867-baa5-4854-a404-7fb5853240b2.png)![CleanShot 2026-06-15 at 21.55.21.png](https://app.graphite.com/user-attachments/assets/223aafcb-fafd-45f4-92a3-be24ad3754ec.png)![CleanShot 2026-06-15 at 21.55.12.png](https://app.graphite.com/user-attachments/assets/773ab9e0-3744-48ee-b073-9b0214a9642a.png)![CleanShot 2026-06-15 at 22.23.01.png](https://app.graphite.com/user-attachments/assets/8cd8c17a-200e-4659-97e3-31a119521225.png)

