### PR TITLE
fix: update with-react-three-fiber example for React 19 and Three.js …

### DIFF
--- a/with-react-three-fiber/App.js
+++ b/with-react-three-fiber/App.js
@@ -5,17 +5,14 @@ import { StyleSheet, View } from "react-native";
 import { Canvas, useFrame } from "@react-three/fiber";
 
 function Box(props) {
-  // This reference will give us direct access to the mesh
   const mesh = useRef();
-
-  // Set up state for the hovered and active state
   const [hovered, setHover] = useState(false);
   const [active, setActive] = useState(false);
 
-  // Rotate mesh every frame, this is outside of React without overhead
-  useFrame(() => {
+  useFrame((state, delta) => {
     if (mesh && mesh.current) {
-      mesh.current.rotation.x = mesh.current.rotation.y += 0.01;
+      mesh.current.rotation.x += delta;
+      mesh.current.rotation.y += delta;
     }
   });
 
@@ -23,16 +20,13 @@ function Box(props) {
     <mesh
       {...props}
       ref={mesh}
-      scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
+      scale={active ? 1.5 : 1}
       onClick={(e) => setActive(!active)}
       onPointerOver={(e) => setHover(true)}
       onPointerOut={(e) => setHover(false)}
     >
-      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
-      <meshStandardMaterial
-        attach="material"
-        color={hovered ? "hotpink" : "orange"}
-      />
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={hovered ? "hotpink" : "orange"} />
     </mesh>
   );
 }
@@ -41,8 +35,8 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Canvas>
-        <ambientLight />
-        <pointLight position={[10, 10, 10]} />
+        <ambientLight intensity={Math.PI / 2} />
+        <pointLight position={[10, 10, 10]} decay={0} intensity={Math.PI} />
         <Box position={[-1.2, 0, 0]} />
         <Box position={[1.2, 0, 0]} />
       </Canvas>

--- a/with-react-three-fiber/package.json
+++ b/with-react-three-fiber/package.json
@@ -1,17 +1,17 @@
 {
   "dependencies": {
-    "@react-three/fiber": "^8.3.1",
+    "@react-three/fiber": "^9.6.1",
     "expo": "^56.0.4",
     "expo-asset": "~56.0.14",
     "expo-file-system": "~56.0.7",
     "expo-gl": "~56.0.5",
     "expo-modules-core": "~56.0.12",
-    "expo-three": "^6.2.0",
+    "expo-three": "^8.0.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
     "react-native-web": "^0.21.0",
-    "three": "^0.145.0"
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@expo/metro-runtime": "~56.0.12"


### PR DESCRIPTION
…v9 compatibility

- Bump @react-three/fiber to v9, three to 0.184, expo-three to v8
- Replace removed boxBufferGeometry with boxGeometry
- Update useFrame to use delta instead of direct mutation
- Update light intensity to use Math.PI convention
- Fixes #690