### PR TITLE
feat: add with-app-integrity example

### DIFF
--- a/with-app-integrity/.env.example
+++ b/with-app-integrity/.env.example
@@ -1,0 +1,13 @@
+# Client (public) — Google Cloud project number for Play Integrity.
+EXPO_PUBLIC_CLOUD_PROJECT_NUMBER=""
+# Optional — point the client at a deployed server (defaults to the dev server).
+EXPO_PUBLIC_API_URL=""
+
+# Google Play Integrity (server) — path to the service account JSON.
+GOOGLE_APPLICATION_CREDENTIALS=""
+GOOGLE_PLAY_APP_PACKAGE_NAME=""
+
+# Apple App Attest (server).
+IOS_BUNDLE_IDENTIFIER=""
+IOS_TEAM_IDENTIFIER=""
+IOS_ALLOW_DEVELOPMENT_ENVIRONMENT=""

--- a/with-app-integrity/README.md
+++ b/with-app-integrity/README.md
@@ -1,0 +1,48 @@
+# App Integrity Example
+
+<p>
+  <!-- iOS -->
+  <img alt="Supports Expo iOS" longdesc="Supports Expo iOS" src="https://img.shields.io/badge/iOS-4630EB.svg?style=flat-square&logo=APPLE&labelColor=999999&logoColor=fff" />
+  <!-- Android -->
+  <img alt="Supports Expo Android" longdesc="Supports Expo Android" src="https://img.shields.io/badge/Android-4630EB.svg?style=flat-square&logo=ANDROID&labelColor=A4C639&logoColor=fff" />
+</p>
+
+Verify that requests come from a genuine, untampered app on a real device using [Expo App Integrity](https://docs.expo.dev/versions/latest/sdk/app-integrity/) — [App Attest](https://developer.apple.com/documentation/devicecheck) on iOS and [Play Integrity](https://developer.android.com/google/play/integrity) on Android — with server-side verification via Expo Router API routes.
+
+## Launch your own
+
+[![Launch with Expo](https://github.com/expo/examples/blob/master/.gh-assets/launch.svg?raw=true)](https://launch.expo.dev/?github=https://github.com/expo/examples/tree/master/with-app-integrity)
+
+## 🚀 How to use
+
+- Install packages with `yarn` or `npm install`.
+  - If you have native iOS code run `npx pod-install`
+- Copy `.env.example` to `.env` and add your Apple and Google credentials.
+- Run `yarn start` or `npm run start` to start the bundler (it also serves the API routes on Node).
+- Open the project in a development build on a real device to try it. App Attest and Play Integrity don't work in Expo Go or on simulators/emulators.
+- Set `EXPO_PUBLIC_API_URL` to a URL the device can reach (your machine's LAN URL, or a deployed server).
+
+### 📁 File Structure
+
+```
+with-app-integrity
+├── app
+│   ├── _layout.tsx ➡️ Expo Router root stack
+│   ├── index.tsx ➡️ Client UI + attestation/assertion flow
+│   └── api
+│       ├── challenge+api.ts ➡️ Issues one-time challenges
+│       └── verify+api.ts ➡️ Verifies attestations, assertions, and tokens
+├── helpers
+│   ├── store.ts ➡️ In-memory challenge & attested-key store
+│   ├── verify-ios.ts ➡️ App Attest verification (node-app-attest)
+│   ├── verify-android.ts ➡️ Play Integrity verification (@googleapis/playintegrity)
+│   └── is-valid-android-request.ts ➡️ Play Integrity verdict checks
+├── app.config.js ➡️ Expo config file
+└── .env.example ➡️ Apple & Google credentials template
+```
+
+## 📝 Notes
+
+- Learn more about [Expo App Integrity](https://docs.expo.dev/versions/latest/sdk/app-integrity/).
+- Learn more about [Development Builds](https://docs.expo.dev/develop/development-builds/create-a-build/)
+- Server verification uses [node-app-attest](https://github.com/uebelack/node-app-attest) (iOS) and [@googleapis/playintegrity](https://www.npmjs.com/package/@googleapis/playintegrity) (Android).

--- a/with-app-integrity/app.config.js
+++ b/with-app-integrity/app.config.js
@@ -1,0 +1,23 @@
+/** @type {import('expo/config').ExpoConfig} */
+module.exports = {
+  name: "with-app-integrity",
+  slug: "with-app-integrity",
+  scheme: "withappintegrity",
+  icon: "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/icon.png?raw=true",
+  splash: {
+    image: "https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/splash.png?raw=true",
+    resizeMode: "contain",
+    backgroundColor: "#ffffff",
+  },
+  ios: {
+    bundleIdentifier: "com.example.withappintegrity",
+  },
+  android: {
+    package: "com.example.withappintegrity",
+  },
+  web: {
+    bundler: "metro",
+    output: "server",
+  },
+  plugins: ["expo-router", "expo-secure-store"],
+};

--- a/with-app-integrity/app/_layout.tsx
+++ b/with-app-integrity/app/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function RootLayout() {
+  return (
+    <Stack screenOptions={{ headerTitle: "App Integrity" }}>
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}

--- a/with-app-integrity/app/api/challenge+api.ts
+++ b/with-app-integrity/app/api/challenge+api.ts
@@ -1,0 +1,9 @@
+import { createChallenge } from "../../helpers/store";
+
+// GET /api/challenge -> { challenge }
+//
+// The client sends `challenge` to App Attest / Play Integrity, then returns the
+// same `challenge` to /api/verify, which validates and consumes it.
+export function GET() {
+  return Response.json(createChallenge());
+}

--- a/with-app-integrity/app/api/verify+api.ts
+++ b/with-app-integrity/app/api/verify+api.ts
@@ -1,0 +1,42 @@
+import { consumeChallenge } from "../../helpers/store";
+import { verifyAndroidToken } from "../../helpers/verify-android";
+import { verifyIosAssertion, verifyIosAttestation } from "../../helpers/verify-ios";
+
+// POST /api/verify
+// Body: { kind, challenge, ...platform-specific fields }
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { kind, challenge } = body;
+
+    if (!challenge || !consumeChallenge(challenge)) {
+      return Response.json({ error: "challenge invalid or expired" }, { status: 400 });
+    }
+
+    switch (kind) {
+      case "ios-attest":
+        return Response.json(
+          await verifyIosAttestation({
+            keyId: body.keyId,
+            attestation: body.attestation,
+            challenge,
+          }),
+        );
+      case "ios-assert":
+        return Response.json(
+          await verifyIosAssertion({
+            keyId: body.keyId,
+            assertion: body.assertion,
+            challenge,
+          }),
+        );
+      case "android":
+        return Response.json(await verifyAndroidToken({ token: body.token, challenge }));
+      default:
+        return Response.json({ error: `unknown kind: ${kind}` }, { status: 400 });
+    }
+  } catch (error) {
+    console.error("verify error:", error);
+    return Response.json({ error: error instanceof Error ? error.message : "verification failed" }, { status: 400 });
+  }
+}

--- a/with-app-integrity/app/index.tsx
+++ b/with-app-integrity/app/index.tsx
@@ -1,0 +1,194 @@
+import * as AppIntegrity from "@expo/app-integrity";
+import * as SecureStore from "expo-secure-store";
+import { useEffect, useState } from "react";
+import { Button, Platform, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+// Public URL of the deployed Node server running the API routes. Leave empty to
+// use the dev server (relative requests). Required for device/production builds.
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "";
+const CLOUD_PROJECT_NUMBER = process.env.EXPO_PUBLIC_CLOUD_PROJECT_NUMBER ?? "";
+
+// SecureStore key under which the attested App Attest key identifier is kept.
+const KEY_ID_STORE = "appattest.keyId";
+
+async function getChallenge(): Promise<{ challenge: string }> {
+  const res = await fetch(`${API_URL}/api/challenge`);
+  if (!res.ok) throw new Error(`challenge failed: ${res.status}`);
+  return res.json();
+}
+
+async function verify(body: Record<string, unknown>) {
+  const res = await fetch(`${API_URL}/api/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(json.error ?? `verify failed: ${res.status}`);
+  return json;
+}
+
+export default function Index() {
+  const insets = useSafeAreaInsets();
+  const [log, setLog] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  // The attested keyId, restored from SecureStore. When set, assertions are
+  // available without re-attesting.
+  const [keyId, setKeyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (Platform.OS === "ios") {
+      SecureStore.getItemAsync(KEY_ID_STORE)
+        .then(setKeyId)
+        .catch(() => {});
+    }
+  }, []);
+
+  const append = (line: string) => setLog((prev) => [...prev, line]);
+
+  async function run(fn: () => Promise<void>) {
+    setBusy(true);
+    setLog([]);
+    try {
+      await fn();
+    } catch (e) {
+      append(`❌ ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runAttestation() {
+    append(`▶️ Attesting on ${Platform.OS}…`);
+    if (!AppIntegrity.isSupported) {
+      append("❌ App Attest is not supported on this device.");
+      return;
+    }
+
+    const newKeyId = await AppIntegrity.generateKeyAsync();
+    append(`🔑 keyId: ${newKeyId}`);
+
+    const { challenge } = await getChallenge();
+    const attestation = await AppIntegrity.attestKeyAsync(newKeyId, challenge);
+    append("📤 sending attestation to server…");
+    const result = await verify({
+      kind: "ios-attest",
+      challenge,
+      keyId: newKeyId,
+      attestation,
+    });
+    append(`✅ attestation verified: ${JSON.stringify(result)}`);
+
+    // Persist the attested key so assertions can use it later.
+    await SecureStore.setItemAsync(KEY_ID_STORE, newKeyId);
+    setKeyId(newKeyId);
+    append("💾 keyId saved to SecureStore");
+  }
+
+  async function runAssertion() {
+    const storedKeyId = await SecureStore.getItemAsync(KEY_ID_STORE);
+    if (!storedKeyId) {
+      append("❌ No attested key found. Run attestation first.");
+      setKeyId(null);
+      return;
+    }
+    append(`🔑 using stored keyId: ${storedKeyId}`);
+
+    const { challenge } = await getChallenge();
+    const assertion = await AppIntegrity.generateAssertionAsync(storedKeyId, challenge);
+    append("📤 sending assertion to server…");
+    const result = await verify({
+      kind: "ios-assert",
+      challenge,
+      keyId: storedKeyId,
+      assertion,
+    });
+    append(`✅ assertion verified: ${JSON.stringify(result)}`);
+  }
+
+  async function runAndroid() {
+    append("▶️ Running integrity check on android…");
+    if (!CLOUD_PROJECT_NUMBER) {
+      append("❌ Set EXPO_PUBLIC_CLOUD_PROJECT_NUMBER in your .env first.");
+      return;
+    }
+    await AppIntegrity.prepareIntegrityTokenProviderAsync(CLOUD_PROJECT_NUMBER);
+    append("⚙️ integrity token provider ready");
+
+    const { challenge } = await getChallenge();
+    const token = await AppIntegrity.requestIntegrityCheckAsync(challenge);
+    append("📤 sending integrity token to server…");
+    const result = await verify({ kind: "android", challenge, token });
+    append(`✅ token verified: ${JSON.stringify(result)}`);
+  }
+
+  return (
+    <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
+      <Text style={styles.title}>Device & app attestation</Text>
+      <Text style={styles.subtitle}>Run the platform integrity flow, then verify the result on the server.</Text>
+
+      <View style={styles.buttons}>
+        {Platform.OS === "android" ? (
+          <Button title={busy ? "Running…" : "Run integrity check"} onPress={() => run(runAndroid)} disabled={busy} />
+        ) : (
+          <>
+            <Button title={busy ? "Running…" : "Run attestation"} onPress={() => run(runAttestation)} disabled={busy} />
+            {keyId ? (
+              <Button title={busy ? "Running…" : "Run assertion"} onPress={() => run(runAssertion)} disabled={busy} />
+            ) : null}
+          </>
+        )}
+      </View>
+
+      <ScrollView style={styles.log} contentContainerStyle={styles.logContent}>
+        {log.length === 0 ? (
+          <Text style={styles.placeholder}>Results will appear here.</Text>
+        ) : (
+          log.map((line, i) => (
+            <Text key={i} style={styles.logLine} selectable>
+              {line}
+            </Text>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    gap: 12,
+    backgroundColor: "#fff",
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "600",
+  },
+  subtitle: {
+    fontSize: 14,
+    color: "#555",
+  },
+  buttons: {
+    gap: 8,
+  },
+  log: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#e0e0e0",
+    borderRadius: 8,
+  },
+  logContent: {
+    padding: 12,
+    gap: 6,
+  },
+  placeholder: {
+    color: "#999",
+  },
+  logLine: {
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace" }),
+    fontSize: 12,
+  },
+});

--- a/with-app-integrity/expo-env.d.ts
+++ b/with-app-integrity/expo-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="expo/types" />
+
+// NOTE: This file should not be edited and should be in your git ignore.

--- a/with-app-integrity/helpers/is-valid-android-request.ts
+++ b/with-app-integrity/helpers/is-valid-android-request.ts
@@ -1,0 +1,30 @@
+import type { playintegrity_v1 } from "@googleapis/playintegrity";
+
+// Validates a decoded Play Integrity verdict against the original request.
+// Ported from the reference push-notifications-service.
+export function isValidAndroidRequest(
+  requestDetails: playintegrity_v1.Schema$RequestDetails | null | undefined,
+  appIntegrity: playintegrity_v1.Schema$AppIntegrity | null | undefined,
+  deviceIntegrity: playintegrity_v1.Schema$DeviceIntegrity | null | undefined,
+  packageName: string,
+  challenge: string,
+): boolean {
+  if (!requestDetails || !appIntegrity || !deviceIntegrity) {
+    return false;
+  }
+
+  const timestampMillis =
+    typeof requestDetails.timestampMillis === "string"
+      ? parseInt(requestDetails.timestampMillis, 10)
+      : requestDetails.timestampMillis;
+
+  return (
+    requestDetails.requestPackageName?.toLowerCase() === packageName.toLowerCase() &&
+    typeof timestampMillis === "number" &&
+    !isNaN(timestampMillis) &&
+    Date.now() - timestampMillis < 120000 &&
+    requestDetails.requestHash === challenge &&
+    appIntegrity.appRecognitionVerdict === "PLAY_RECOGNIZED" &&
+    (deviceIntegrity.deviceRecognitionVerdict?.includes("MEETS_DEVICE_INTEGRITY") ?? false)
+  );
+}

--- a/with-app-integrity/helpers/store.ts
+++ b/with-app-integrity/helpers/store.ts
@@ -1,0 +1,53 @@
+// In-memory stores kept on `globalThis` so they survive the Metro dev server
+// re-evaluating route modules between requests (a module-level `const` would
+// reset on every request) and are shared across the separate `+api` bundles.
+// State is still lost on a full process restart and is NOT shared across
+// multiple server instances — a production backend would use a shared store
+// (Redis / SQL).
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+type AttestedKey = { publicKey: string; signCount: number };
+
+type IntegrityStore = {
+  challenges: Map<string, number>; // challenge -> createdAt
+  attestedKeys: Map<string, AttestedKey>; // keyId -> key
+};
+
+const globalRef = globalThis as unknown as {
+  __appIntegrityStore?: IntegrityStore;
+};
+
+const store: IntegrityStore = (globalRef.__appIntegrityStore ??= {
+  challenges: new Map(),
+  attestedKeys: new Map(),
+});
+
+/** Issues a random, single-use challenge. */
+export function createChallenge(): { challenge: string } {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  const challenge = btoa(String.fromCharCode(...bytes));
+  store.challenges.set(challenge, Date.now());
+  return { challenge };
+}
+
+/** Validates a challenge and removes it (single use). */
+export function consumeChallenge(challenge: string): boolean {
+  const createdAt = store.challenges.get(challenge);
+  store.challenges.delete(challenge);
+  if (createdAt === undefined) return false;
+  return Date.now() - createdAt <= CHALLENGE_TTL_MS;
+}
+
+export function saveAttestedKey(keyId: string, publicKey: string) {
+  store.attestedKeys.set(keyId, { publicKey, signCount: 0 });
+}
+
+export function getAttestedKey(keyId: string): AttestedKey | null {
+  return store.attestedKeys.get(keyId) ?? null;
+}
+
+export function updateSignCount(keyId: string, signCount: number) {
+  const key = store.attestedKeys.get(keyId);
+  if (key) key.signCount = signCount;
+}

--- a/with-app-integrity/helpers/verify-android.ts
+++ b/with-app-integrity/helpers/verify-android.ts
@@ -1,0 +1,58 @@
+// Android Play Integrity verification. The standard-request token is decoded
+// server-to-server by Google's Play Integrity API using a service account, then
+// the verdict is validated. See:
+// https://developer.android.com/google/play/integrity/standard
+import { auth as googleAuth, playintegrity } from "@googleapis/playintegrity";
+
+import { isValidAndroidRequest } from "./is-valid-android-request";
+
+let authClient: ReturnType<typeof createAuthClient> | null = null;
+
+function createAuthClient() {
+  return new googleAuth.GoogleAuth({
+    keyFile: requireEnv("GOOGLE_APPLICATION_CREDENTIALS"),
+    scopes: ["https://www.googleapis.com/auth/playintegrity"],
+  });
+}
+
+function getAuthClient() {
+  if (!authClient) authClient = createAuthClient();
+  return authClient;
+}
+
+type AndroidInput = {
+  token: string;
+  challenge: string; // bound into the token as the request hash
+};
+
+export async function verifyAndroidToken({ token, challenge }: AndroidInput) {
+  const packageName = requireEnv("GOOGLE_PLAY_APP_PACKAGE_NAME");
+
+  const client = playintegrity({ version: "v1", auth: getAuthClient() });
+  const result = await client.v1.decodeIntegrityToken({
+    packageName,
+    requestBody: { integrityToken: token },
+  });
+
+  const payload = result.data?.tokenPayloadExternal;
+  if (!payload) {
+    throw new Error("no payload returned from Play Integrity");
+  }
+
+  const { requestDetails, appIntegrity, deviceIntegrity } = payload;
+  if (!isValidAndroidRequest(requestDetails, appIntegrity, deviceIntegrity, packageName, challenge)) {
+    throw new Error("Play Integrity verdict failed validation");
+  }
+
+  return {
+    verified: true,
+    appRecognitionVerdict: appIntegrity?.appRecognitionVerdict,
+    deviceRecognitionVerdict: deviceIntegrity?.deviceRecognitionVerdict,
+  };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing env var: ${name}`);
+  return value;
+}

--- a/with-app-integrity/helpers/verify-ios.ts
+++ b/with-app-integrity/helpers/verify-ios.ts
@@ -1,0 +1,62 @@
+// iOS App Attest verification using `node-app-attest`, which implements Apple's
+// attestation/assertion protocol on top of Node's crypto + cbor.
+import { verifyAssertion, verifyAttestation } from "node-app-attest";
+
+import { getAttestedKey, saveAttestedKey, updateSignCount } from "./store";
+
+type IosAttestInput = {
+  keyId: string;
+  attestation: string; // base64
+  challenge: string;
+};
+
+type IosAssertInput = {
+  keyId: string;
+  assertion: string; // base64
+  challenge: string;
+};
+
+export function verifyIosAttestation({ keyId, attestation, challenge }: IosAttestInput) {
+  const { publicKey } = verifyAttestation({
+    attestation: Buffer.from(attestation, "base64"),
+    challenge,
+    keyId,
+    bundleIdentifier: requireEnv("IOS_BUNDLE_IDENTIFIER"),
+    teamIdentifier: requireEnv("IOS_TEAM_IDENTIFIER"),
+    allowDevelopmentEnvironment: process.env.IOS_ALLOW_DEVELOPMENT_ENVIRONMENT === "true",
+  });
+
+  // Persist the public key so future assertions can be verified without
+  // re-attesting (signCount starts at 0).
+  saveAttestedKey(keyId, publicKey);
+
+  return { verified: true, keyId };
+}
+
+export function verifyIosAssertion({ keyId, assertion, challenge }: IosAssertInput) {
+  const stored = getAttestedKey(keyId);
+  if (!stored) {
+    throw new Error("unknown keyId — attest the key before sending assertions");
+  }
+
+  // The native module signs SHA-256(challenge), so the assertion payload is the
+  // challenge string itself.
+  const { signCount } = verifyAssertion({
+    assertion: Buffer.from(assertion, "base64"),
+    payload: challenge,
+    publicKey: stored.publicKey,
+    bundleIdentifier: requireEnv("IOS_BUNDLE_IDENTIFIER"),
+    teamIdentifier: requireEnv("IOS_TEAM_IDENTIFIER"),
+    signCount: stored.signCount,
+  });
+
+  updateSignCount(keyId, signCount);
+
+  return { verified: true, keyId, signCount };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing env var: ${name}`);
+  return value;
+}

--- a/with-app-integrity/package.json
+++ b/with-app-integrity/package.json
@@ -1,0 +1,28 @@
+{
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "@expo/app-integrity": "~56.0.3",
+    "@googleapis/playintegrity": "^22.0.0",
+    "expo": "^56.0.4",
+    "expo-constants": "~56.0.18",
+    "expo-linking": "~56.0.14",
+    "expo-router": "~56.2.11",
+    "expo-secure-store": "~56.0.4",
+    "node-app-attest": "^0.0.8",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "react-native": "0.85.3",
+    "react-native-safe-area-context": "~5.8.0",
+    "react-native-screens": "~4.25.2",
+    "react-native-web": "^0.21.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.2.14",
+    "typescript": "~6.0.3"
+  }
+}

--- a/with-app-integrity/tsconfig.json
+++ b/with-app-integrity/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+}


### PR DESCRIPTION
This PR implements a `with-app-integrity` example into the expo-examples repository, creating an example with [App Integrity](https://docs.expo.dev/versions/latest/sdk/app-integrity/) - ensuring the backend resources are accessed only by legitimate installations of an app running on genuine devices.

Demo:

https://github.com/user-attachments/assets/4968e98d-f6e2-49ff-b014-78f6573dfdd2