### PR TITLE
Skip stickersmash upgrade during automated script upgrades

### DIFF
--- a/upgrade-dependencies.sh
+++ b/upgrade-dependencies.sh
@@ -26,7 +26,7 @@ if [ "$1" == "--upgrade-expo" ]; then
     DIRNAME=${d%/}
     echo "Upgrading $DIRNAME..."
 
-    if [ "$DIRNAME" == "with-tv" ] || [ "$DIRNAME" == "with-router-tv" ]; then
+    if [ "$DIRNAME" == "with-tv" ] || [ "$DIRNAME" == "with-router-tv" ] || [ "$DIRNAME" == "stickersmash" ]; then
       echo "$DIRNAME requires manual attention"
       continue
     fi


### PR DESCRIPTION
## Why

We need to pin sticksmash example repo to SDK 54 for Expo tutorial.